### PR TITLE
refactor(runtime-hardening): SSRF fix, template-gen injection gate, and service APIs

### DIFF
--- a/docling_graph/cli/commands/template.py
+++ b/docling_graph/cli/commands/template.py
@@ -20,10 +20,8 @@ itself is optional for every subcommand (``load_config_optional``).
 
 import logging
 import os
-import re
 import sys
 import tempfile
-import threading
 import types
 from collections import Counter
 from pathlib import Path
@@ -196,130 +194,27 @@ def _build_llm_call(
     *,
     structured_output: bool = True,
 ) -> tuple[LlmCallFn, "EffectiveModelConfig"]:
-    """Bind an ``llm_call_fn`` to a LiteLLM client (stages.py two-liner).
+    """Bind an ``llm_call_fn`` to a LiteLLM client and resolve its model config.
 
-    The callable follows the ``templategen.induce.documents`` contract and owns
-    truncation handling: one retry with escalated ``max_tokens`` (doubled,
-    capped at half the model's context window). The retry fires whether the
-    truncated response was salvaged into JSON or failed to parse outright —
-    the unrecoverable case surfaces as a ``ClientError`` and needs the
-    escalation the most. The retry's result is returned (or its error raised)
-    either way.
-
-    ``structured_output=False`` (the one-shot strategy) requests plain
-    ``json_object`` decoding instead of a schema grammar — small models that
-    degenerate under guided decoding answer normally, and the response
-    handler's fence-stripping/repair absorbs the slack.
-
-    Thread-safe by construction: induction runs calls concurrently
-    (``templategen.workers``), and one shared client would race on
-    ``last_call_diagnostics`` and the escalation's ``max_tokens`` swap — so
-    every thread gets its own client instance (the one built eagerly here
-    doubles as the fail-fast credential check and the building thread's
-    client).
+    Thin CLI adapter over the public
+    :func:`docling_graph.templategen.build_llm_call_fn`: it pulls
+    ``llm_overrides`` out of the ``config.yaml`` dict and additionally returns the
+    resolved :class:`EffectiveModelConfig` the CLI needs for budget/batch sizing
+    (``_effective_budget_chars`` / ``_pass2_batch_size``). The callable's
+    thread-safety and truncation-escalation behavior live in the public builder.
     """
-    import copy as _copy
-
-    from docling_graph.exceptions import ClientError
-    from docling_graph.llm_clients import get_client
     from docling_graph.llm_clients.config import resolve_effective_model_config
+    from docling_graph.templategen import build_llm_call_fn
 
     overrides = get_config_value(config or {}, "llm_overrides")
-    effective = resolve_effective_model_config(
-        provider, model, overrides=overrides if isinstance(overrides, dict) else None
+    overrides = overrides if isinstance(overrides, dict) else None
+    effective = resolve_effective_model_config(provider, model, overrides=overrides)
+    llm_call_fn = build_llm_call_fn(
+        provider,
+        model,
+        llm_overrides=overrides,
+        structured_output=structured_output,
     )
-    client_factory = get_client(provider)
-    thread_clients = threading.local()
-    # Every client gets its own DEEP COPY of the config: the escalation retry
-    # mutates generation.max_tokens, and a config shared across thread clients
-    # lets concurrent escalations compound (4092 -> 8184 -> 16368 -> 65472...)
-    # and race on the restore — the budget must never ratchet across calls.
-    thread_clients.client = client_factory(_copy.deepcopy(effective))  # fail fast, pre-spend
-    # Escalation baseline is fixed at build time: a retry may double the
-    # CONFIGURED budget once, never the (possibly already escalated) live one.
-    baseline_max_tokens = int(
-        getattr(getattr(effective, "generation", None), "max_tokens", 0)
-        or getattr(effective, "max_output_tokens", 0)
-        or 0
-    )
-
-    def llm_call_fn(*, prompt: dict[str, str], schema_json: str, context: str) -> Any:
-        client = getattr(thread_clients, "client", None)
-        if client is None:
-            client = thread_clients.client = client_factory(_copy.deepcopy(effective))
-        # OpenAI-family providers require response_format schema names to match
-        # ^[a-zA-Z0-9_-]+$ (<=64 chars); the context tag carries ':' and the
-        # source filename's '.', so sanitize before it reaches the provider.
-        schema_name = re.sub(r"[^a-zA-Z0-9_-]", "_", context)[:40]
-
-        def call() -> Any:
-            return client.get_json_response(
-                prompt,
-                schema_json,
-                structured_output=structured_output,
-                response_top_level="object",
-                response_schema_name=schema_name,
-            )
-
-        def warn_still_truncated(max_tokens: int) -> None:
-            logger.warning(
-                "Induction call '%s' is still truncated at max_tokens=%d — this pass "
-                "should need far less output, so the model is likely looping "
-                "(degenerate repetition); keeping the salvaged partial result. A "
-                "stronger model is the reliable fix; llm_overrides.max_output_tokens "
-                "raises the budget only if the output is genuinely large",
-                context,
-                max_tokens,
-                extra={"component": "TemplateInduction"},
-            )
-
-        out: Any = None
-        error: ClientError | None = None
-        try:
-            out = call()
-        except ClientError as e:
-            # Truncated output that could not be repaired into JSON raises,
-            # but the client diagnostics still flag the truncation.
-            if not client.last_call_diagnostics.get("truncated"):
-                raise
-            error = e
-        if not client.last_call_diagnostics.get("truncated"):
-            return out
-        generation = getattr(client, "_generation", None)
-        current = int(getattr(client, "max_tokens", 0) or 0)
-        context_limit = int(getattr(client, "context_limit", 0) or 0)
-        # Hard ceiling: one doubling of the configured budget, ever. A model
-        # in a repetition loop truncates at ANY budget; escalating past 2x
-        # only converts junk into minutes of generation time (and timeouts).
-        ceiling = 2 * (baseline_max_tokens or current)
-        if context_limit > 0:
-            ceiling = min(ceiling, context_limit // 2)
-        escalated = min(current * 2, ceiling)
-        if generation is None or current <= 0 or escalated <= current:
-            if error is not None:
-                warn_still_truncated(current)
-                raise error
-            return out
-        logger.warning(
-            "Induction call '%s' was truncated; retrying once with max_tokens=%d",
-            context,
-            escalated,
-            extra={"component": "TemplateInduction"},
-        )
-        original = getattr(generation, "max_tokens", None)
-        try:
-            generation.max_tokens = escalated
-            out = call()
-        except ClientError:
-            if client.last_call_diagnostics.get("truncated"):
-                warn_still_truncated(escalated)
-            raise
-        finally:
-            generation.max_tokens = original
-        if client.last_call_diagnostics.get("truncated"):
-            warn_still_truncated(escalated)
-        return out
-
     return llm_call_fn, effective
 
 

--- a/docling_graph/config.py
+++ b/docling_graph/config.py
@@ -291,6 +291,18 @@ class PipelineConfig(BaseModel):
         ),
     )
 
+    # Per-run garbage collection. A full gc.collect() after every run is a
+    # stop-the-world pause; long-lived services running many small jobs can set
+    # this False to avoid the tail-latency cost (the CUDA cache purge still runs).
+    gc_collect: bool = Field(
+        default=True,
+        description=(
+            "Run a full gc.collect() after each pipeline run. Keep True for CLI/"
+            "batch use; set False in a long-lived service to avoid the per-run "
+            "stop-the-world pause."
+        ),
+    )
+
     @field_validator("source", "output_dir")
     @classmethod
     def _path_to_str(cls, v: Union[str, Path]) -> str:
@@ -421,6 +433,7 @@ class PipelineConfig(BaseModel):
             "reverse_edges": self.reverse_edges,
             "output_dir": self.output_dir,
             "dump_to_disk": self.dump_to_disk,
+            "gc_collect": self.gc_collect,
             "models": self.models.model_dump(),
             "llm_overrides": self.llm_overrides.model_dump(),
             "llm_client": self.llm_client,

--- a/docling_graph/core/converters/graph_converter.py
+++ b/docling_graph/core/converters/graph_converter.py
@@ -19,6 +19,7 @@ from typing import Any, List, Mapping, Optional, Set
 import networkx as nx
 from pydantic import BaseModel
 
+from ...exceptions import GraphError
 from ...logging_utils import get_component_logger
 from ..provenance.identity import PROVENANCE_NODE_ATTR, iter_provenance_views
 from ..provenance.models import template_schema_hash
@@ -227,7 +228,10 @@ class GraphConverter:
             Tuple of (graph, metadata)
         """
         if not model_instances:
-            raise ValueError("Cannot create graph from empty model list")
+            raise GraphError(
+                "Cannot create graph from empty model list",
+                details={"reason": "no_models_extracted"},
+            )
 
         # Pre-register all models to ensure consistent node IDs across batches
         logger.info("Pre-registering models for deterministic node IDs...")

--- a/docling_graph/core/exporters/__init__.py
+++ b/docling_graph/core/exporters/__init__.py
@@ -3,6 +3,6 @@
 from .csv_exporter import CSVExporter
 from .cypher_exporter import CypherExporter
 from .docling_exporter import DoclingExporter
-from .json_exporter import JSONExporter
+from .json_exporter import JSONExporter, graph_to_dict
 
-__all__ = ["CSVExporter", "CypherExporter", "DoclingExporter", "JSONExporter"]
+__all__ = ["CSVExporter", "CypherExporter", "DoclingExporter", "JSONExporter", "graph_to_dict"]

--- a/docling_graph/core/exporters/json_exporter.py
+++ b/docling_graph/core/exporters/json_exporter.py
@@ -11,6 +11,21 @@ from ..converters.config import ExportConfig
 from ..utils.string_formatter import json_serializable
 
 
+def graph_to_dict(graph: nx.DiGraph) -> Dict[str, Any]:
+    """Serialize a graph to the canonical docling-graph JSON shape.
+
+    Public, file-free entry point for the shape ``graph.json`` uses:
+    ``{"nodes": [...], "edges": [...], "metadata": {...}, "graph": {...}}``. The
+    round-trip inverse is
+    :func:`docling_graph.core.importers.graph_json.load_graph_from_dict`.
+
+    Note: node/edge attributes may contain non-JSON-native values (dates,
+    Decimals, …); pass :func:`docling_graph.core.utils.string_formatter.json_serializable`
+    as ``json.dumps(..., default=...)`` when encoding the result.
+    """
+    return JSONExporter._graph_to_dict(graph)
+
+
 class JSONExporter:
     """Export graph to JSON format."""
 

--- a/docling_graph/core/extractors/backends/llm_backend.py
+++ b/docling_graph/core/extractors/backends/llm_backend.py
@@ -1806,13 +1806,18 @@ class LlmBackend:
 
             return EmptyResponse()
 
-    def cleanup(self) -> None:
+    def cleanup(self, collect: bool = True) -> None:
         """
         Clean up LLM client resources.
 
         Note: Most LLM clients use stateless HTTP APIs and don't require cleanup.
         This method is provided for consistency with VlmBackend and handles any
         clients that may have cleanup methods.
+
+        Args:
+            collect: Run a full ``gc.collect()`` after releasing resources.
+                Long-lived services pass False (via ``PipelineConfig.gc_collect``)
+                to avoid the per-run stop-the-world pause.
         """
         try:
             # Release the client reference
@@ -1824,8 +1829,8 @@ class LlmBackend:
                     cleanup_fn()
                 del self.client
 
-            # Force garbage collection
-            gc.collect()
+            if collect:
+                gc.collect()
 
             logger.info("Cleaned up resources")
 

--- a/docling_graph/core/extractors/backends/vlm_backend.py
+++ b/docling_graph/core/extractors/backends/vlm_backend.py
@@ -123,7 +123,7 @@ class VlmBackend:
             logger.error("Error during VLM extraction: %s: %s", type(e).__name__, e)
             return []
 
-    def cleanup(self) -> None:
+    def cleanup(self, collect: bool = True) -> None:
         """
         Enhanced GPU cleanup with memory tracking.
 
@@ -132,7 +132,8 @@ class VlmBackend:
         2. Model-to-CPU transfer (if model exists)
         3. Resource deletion
         4. CUDA cache clearing
-        5. Garbage collection
+        5. Garbage collection (skipped when ``collect`` is False — CUDA cache
+           clearing still runs; see ``PipelineConfig.gc_collect``)
         6. Memory tracking (after cleanup)
         """
         try:
@@ -169,8 +170,8 @@ class VlmBackend:
                 self.doc_extractor = None
                 logger.info("Extractor deleted")
 
-            # Force garbage collection
-            gc.collect()
+            if collect:
+                gc.collect()
 
             # Clear CUDA cache if available
             try:

--- a/docling_graph/core/extractors/document_processor.py
+++ b/docling_graph/core/extractors/document_processor.py
@@ -609,8 +609,14 @@ class DocumentProcessor:
 
         return chunks, metadata_list
 
-    def cleanup(self) -> None:
-        """Clean up document converter resources."""
+    def cleanup(self, collect: bool = True) -> None:
+        """Clean up document converter resources.
+
+        Args:
+            collect: Run a full ``gc.collect()`` after releasing resources.
+                Long-lived services pass False (via ``PipelineConfig.gc_collect``)
+                to avoid the per-run stop-the-world pause.
+        """
         try:
             serve_client = getattr(self, "serve_client", None)
             if serve_client is not None:
@@ -618,7 +624,8 @@ class DocumentProcessor:
                 self.serve_client = None
             if hasattr(self, "converter"):
                 del self.converter
-            gc.collect()
+            if collect:
+                gc.collect()
             logger.info("Cleaned up resources")
         except Exception as e:
             logger.warning("Warning during cleanup: %s", e)

--- a/docling_graph/core/importers/__init__.py
+++ b/docling_graph/core/importers/__init__.py
@@ -5,9 +5,16 @@ the first graph import path in the repo, shared by ``docling-graph merge``
 (and adoptable by inspect/Neo4j-push later).
 """
 
-from .graph_json import load_graph_input, load_graph_json, load_sibling_ledger, resolve_graph_path
+from .graph_json import (
+    load_graph_from_dict,
+    load_graph_input,
+    load_graph_json,
+    load_sibling_ledger,
+    resolve_graph_path,
+)
 
 __all__ = [
+    "load_graph_from_dict",
     "load_graph_input",
     "load_graph_json",
     "load_sibling_ledger",

--- a/docling_graph/core/importers/graph_json.py
+++ b/docling_graph/core/importers/graph_json.py
@@ -66,7 +66,10 @@ def resolve_graph_path(input_path: Path) -> Path:
 
 
 def load_graph_json(path: Path) -> nx.DiGraph:
-    """Load one exported graph.json into an ``nx.DiGraph``.
+    """Load one exported graph.json file into an ``nx.DiGraph``.
+
+    Thin wrapper over :func:`load_graph_from_dict` that reads and parses the
+    file first.
 
     Raises:
         ConfigurationError: When the file is not a docling-graph export
@@ -79,13 +82,41 @@ def load_graph_json(path: Path) -> nx.DiGraph:
         raise ConfigurationError(
             f"Cannot read graph export: {path}", details={"path": str(path)}, cause=e
         ) from e
+    graph = load_graph_from_dict(data, source=str(path))
+    logger.info(
+        "Loaded graph export %s: %s nodes, %s edges (%s)",
+        path,
+        graph.number_of_nodes(),
+        graph.number_of_edges(),
+        str(graph.graph.get("format") or "v1, no graph metadata"),
+    )
+    return graph
 
+
+def load_graph_from_dict(data: dict, *, source: str = "<dict>") -> nx.DiGraph:
+    """Load an in-memory graph.json object (already parsed) into an ``nx.DiGraph``.
+
+    The read-side inverse of ``JSONExporter._graph_to_dict`` for callers that
+    already hold the dict (e.g. an HTTP request body) and want to avoid spooling
+    it to a temp file just to call :func:`load_graph_json`. Validation is
+    identical.
+
+    Args:
+        data: A docling-graph graph export object: ``{"nodes": [...],
+            "edges": [...], "graph"?: {...}, ...}``.
+        source: Label used in error messages (a path, URL, or ``"<dict>"``).
+
+    Raises:
+        ConfigurationError: When ``data`` is not a docling-graph export, is
+            empty, or is structurally corrupt (malformed records, dangling edge
+            endpoints).
+    """
     if not isinstance(data, dict) or "nodes" not in data or "edges" not in data:
         found = sorted(data.keys()) if isinstance(data, dict) else type(data).__name__
         raise ConfigurationError(
             "Not a docling-graph export: expected top-level 'nodes' and 'edges' keys "
             "(the shape JSONExporter writes)",
-            details={"path": str(path), "found": found},
+            details={"source": source, "found": found},
         )
 
     nodes = data["nodes"]
@@ -93,13 +124,13 @@ def load_graph_json(path: Path) -> nx.DiGraph:
     if not isinstance(nodes, list) or not isinstance(edges, list):
         raise ConfigurationError(
             "Malformed graph export: 'nodes' and 'edges' must be lists",
-            details={"path": str(path)},
+            details={"source": source},
         )
     if not nodes:
-        # The exporter refuses to write empty graphs, so this is a hand-made file.
+        # The exporter refuses to write empty graphs, so this is a hand-made input.
         raise ConfigurationError(
             "Graph export contains no nodes (docling-graph never writes empty exports)",
-            details={"path": str(path)},
+            details={"source": source},
         )
 
     graph = nx.DiGraph()
@@ -111,7 +142,14 @@ def load_graph_json(path: Path) -> nx.DiGraph:
         if not isinstance(raw_node, dict) or "id" not in raw_node:
             raise ConfigurationError(
                 "Malformed graph export: every node needs an 'id'",
-                details={"path": str(path), "node": str(raw_node)[:200]},
+                details={"source": source, "node": str(raw_node)[:200]},
+            )
+        # A null/object/array id would leak a raw networkx ValueError/TypeError
+        # (unhashable) instead of this function's ConfigurationError contract.
+        if not isinstance(raw_node["id"], str | int | float | bool):
+            raise ConfigurationError(
+                "Malformed graph export: node 'id' must be a JSON scalar (string/number/bool)",
+                details={"source": source, "node": str(raw_node)[:200]},
             )
         attrs = dict(raw_node)
         # The exporter writes id redundantly (node key + attr); keep the attr —
@@ -122,25 +160,22 @@ def load_graph_json(path: Path) -> nx.DiGraph:
         if not isinstance(raw_edge, dict) or "source" not in raw_edge or "target" not in raw_edge:
             raise ConfigurationError(
                 "Malformed graph export: every edge needs 'source' and 'target'",
-                details={"path": str(path), "edge": str(raw_edge)[:200]},
+                details={"source": source, "edge": str(raw_edge)[:200]},
             )
         attrs = dict(raw_edge)
-        source = attrs.pop("source")
-        target = attrs.pop("target")
-        if source not in graph or target not in graph:
+        edge_source = attrs.pop("source")
+        edge_target = attrs.pop("target")
+        if edge_source not in graph or edge_target not in graph:
             raise ConfigurationError(
                 "Malformed graph export: edge endpoint is not an exported node",
-                details={"path": str(path), "source": str(source), "target": str(target)},
+                details={
+                    "source": source,
+                    "edge_source": str(edge_source),
+                    "edge_target": str(edge_target),
+                },
             )
-        graph.add_edge(source, target, **attrs)
+        graph.add_edge(edge_source, edge_target, **attrs)
 
-    logger.info(
-        "Loaded graph export %s: %s nodes, %s edges (%s)",
-        path,
-        graph.number_of_nodes(),
-        graph.number_of_edges(),
-        str(graph.graph.get("format") or "v1, no graph metadata"),
-    )
     return graph
 
 

--- a/docling_graph/core/input/handlers.py
+++ b/docling_graph/core/input/handlers.py
@@ -5,7 +5,6 @@ This module provides handlers that load various input formats and
 normalize them into a consistent internal representation.
 """
 
-import ipaddress
 import json
 import socket
 import tempfile
@@ -226,113 +225,39 @@ class URLInputHandler(InputHandler):
         Raises:
             ValidationError: If URL resolves to an unsafe IP address
         """
+        parsed = urlparse(url)
+        hostname = parsed.hostname
+
+        if not hostname:
+            raise ValidationError(
+                f"Invalid URL (cannot extract hostname): {url}",
+                details={"url": url},
+            )
+
+        # Resolve EVERY address (all A and AAAA records): a fetch may connect to
+        # any of them, so one safe record must not vouch for an unsafe sibling.
         try:
-            parsed = urlparse(url)
-            hostname = parsed.hostname
-
-            if not hostname:
-                raise ValidationError(
-                    f"Invalid URL (cannot extract hostname): {url}",
-                    details={"url": url},
-                )
-
-            # Resolve hostname to IP address
-            ip_str = socket.gethostbyname(hostname)
-            ip_addr = ipaddress.ip_address(ip_str)
-
-            # Explicitly block cloud metadata endpoint (169.254.169.254) FIRST
-            if ip_str == "169.254.169.254":
-                raise ValidationError(
-                    "Access to cloud metadata endpoint is not allowed: 169.254.169.254",
-                    details={
-                        "url": url,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Cloud metadata endpoint (AWS, Azure, GCP)",
-                    },
-                )
-
-            # Block loopback addresses (127.0.0.0/8, ::1)
-            if ip_addr.is_loopback:
-                raise ValidationError(
-                    f"Access to loopback addresses is not allowed: {ip_str}",
-                    details={
-                        "url": url,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Loopback address",
-                    },
-                )
-
-            # Block link-local addresses (169.254.0.0/16, fe80::/10)
-            if ip_addr.is_link_local:
-                raise ValidationError(
-                    f"Access to link-local addresses is not allowed: {ip_str}",
-                    details={
-                        "url": url,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Link-local address",
-                    },
-                )
-
-            # Block multicast addresses
-            if ip_addr.is_multicast:
-                raise ValidationError(
-                    f"Access to multicast addresses is not allowed: {ip_str}",
-                    details={
-                        "url": url,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Multicast address",
-                    },
-                )
-
-            # Block reserved addresses
-            if ip_addr.is_reserved:
-                raise ValidationError(
-                    f"Access to reserved IP addresses is not allowed: {ip_str}",
-                    details={
-                        "url": url,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Reserved IP address",
-                    },
-                )
-
-            # Block private IP addresses (RFC 1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)
-            # Check this LAST because is_private also returns True for loopback and link-local
-            if ip_addr.is_private:
-                raise ValidationError(
-                    f"Access to private IP addresses is not allowed: {ip_str}",
-                    details={
-                        "url": url,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Private IP address (RFC 1918)",
-                    },
-                )
-
+            addrinfos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+            resolved_ips = sorted({str(info[4][0]) for info in addrinfos})
         except socket.gaierror as e:
             raise ValidationError(
                 f"Failed to resolve hostname: {hostname}",
-                details={
-                    "url": url,
-                    "hostname": hostname,
-                    "error": str(e),
-                },
+                details={"url": url, "hostname": hostname, "error": str(e)},
             ) from e
+
+        # Reuse URLValidator's per-address gate so the two SSRF entry points
+        # (validate-time and this fetch/redirect-time check) can never diverge.
+        from .validators import URLValidator
+
+        try:
+            for ip_str in resolved_ips:
+                URLValidator._validate_ip(url, hostname, ip_str)
         except ValidationError:
-            # Re-raise validation errors
             raise
         except Exception as e:
             raise ValidationError(
                 f"Error validating URL safety: {url}",
-                details={
-                    "url": url,
-                    "error": str(e),
-                    "type": type(e).__name__,
-                },
+                details={"url": url, "error": str(e), "type": type(e).__name__},
             ) from e
 
     def load(self, source: str) -> Path:

--- a/docling_graph/core/input/validators.py
+++ b/docling_graph/core/input/validators.py
@@ -218,86 +218,13 @@ class URLValidator(InputValidator):
                 details={"url": source},
             )
 
-        # Perform DNS resolution and IP validation to prevent SSRF attacks
+        # Perform DNS resolution and IP validation to prevent SSRF attacks.
+        # Resolve EVERY address (all A and AAAA records): the downloader may
+        # connect to any of them, so a single safe first record must not vouch
+        # for an unsafe sibling (multi-record SSRF bypass).
         try:
-            # Resolve hostname to IP address
-            ip_str = socket.gethostbyname(hostname)
-            ip_addr = ipaddress.ip_address(ip_str)
-
-            # Explicitly block cloud metadata endpoint (169.254.169.254) FIRST
-            # This is critical for preventing access to cloud instance metadata
-            if ip_str == "169.254.169.254":
-                raise ValidationError(
-                    "Access to cloud metadata endpoint is not allowed: 169.254.169.254",
-                    details={
-                        "url": source,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Cloud metadata endpoint (AWS, Azure, GCP)",
-                    },
-                )
-
-            # Block loopback addresses (127.0.0.0/8, ::1)
-            if ip_addr.is_loopback:
-                raise ValidationError(
-                    f"Access to loopback addresses is not allowed: {ip_str}",
-                    details={
-                        "url": source,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Loopback address (127.0.0.0/8, ::1)",
-                    },
-                )
-
-            # Block link-local addresses (169.254.0.0/16, fe80::/10)
-            if ip_addr.is_link_local:
-                raise ValidationError(
-                    f"Access to link-local addresses is not allowed: {ip_str}",
-                    details={
-                        "url": source,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Link-local address (169.254.0.0/16, fe80::/10)",
-                    },
-                )
-
-            # Block multicast addresses
-            if ip_addr.is_multicast:
-                raise ValidationError(
-                    f"Access to multicast addresses is not allowed: {ip_str}",
-                    details={
-                        "url": source,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Multicast address",
-                    },
-                )
-
-            # Block reserved addresses
-            if ip_addr.is_reserved:
-                raise ValidationError(
-                    f"Access to reserved IP addresses is not allowed: {ip_str}",
-                    details={
-                        "url": source,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Reserved IP address",
-                    },
-                )
-
-            # Block private IP addresses (RFC 1918)
-            # Check this LAST because is_private also returns True for loopback and link-local
-            if ip_addr.is_private:
-                raise ValidationError(
-                    f"Access to private IP addresses is not allowed: {ip_str}",
-                    details={
-                        "url": source,
-                        "hostname": hostname,
-                        "resolved_ip": ip_str,
-                        "reason": "Private IP address (RFC 1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)",
-                    },
-                )
-
+            addrinfos = socket.getaddrinfo(hostname, None, proto=socket.IPPROTO_TCP)
+            resolved_ips = sorted({str(info[4][0]) for info in addrinfos})
         except socket.gaierror as e:
             # DNS resolution failed
             raise ValidationError(
@@ -309,6 +236,10 @@ class URLValidator(InputValidator):
                     "hint": "Hostname could not be resolved to an IP address",
                 },
             ) from e
+
+        try:
+            for ip_str in resolved_ips:
+                self._validate_ip(source, hostname, ip_str)
         except ValidationError:
             # Re-raise validation errors from IP checks
             raise
@@ -323,6 +254,85 @@ class URLValidator(InputValidator):
                     "type": type(e).__name__,
                 },
             ) from e
+
+    @staticmethod
+    def _validate_ip(source: str, hostname: str, ip_str: str) -> None:
+        """Reject one resolved address if it targets a protected network."""
+        ip_addr = ipaddress.ip_address(ip_str)
+
+        # Explicitly block cloud metadata endpoint (169.254.169.254) FIRST
+        # This is critical for preventing access to cloud instance metadata
+        if ip_str == "169.254.169.254":
+            raise ValidationError(
+                "Access to cloud metadata endpoint is not allowed: 169.254.169.254",
+                details={
+                    "url": source,
+                    "hostname": hostname,
+                    "resolved_ip": ip_str,
+                    "reason": "Cloud metadata endpoint (AWS, Azure, GCP)",
+                },
+            )
+
+        # Block loopback addresses (127.0.0.0/8, ::1)
+        if ip_addr.is_loopback:
+            raise ValidationError(
+                f"Access to loopback addresses is not allowed: {ip_str}",
+                details={
+                    "url": source,
+                    "hostname": hostname,
+                    "resolved_ip": ip_str,
+                    "reason": "Loopback address (127.0.0.0/8, ::1)",
+                },
+            )
+
+        # Block link-local addresses (169.254.0.0/16, fe80::/10)
+        if ip_addr.is_link_local:
+            raise ValidationError(
+                f"Access to link-local addresses is not allowed: {ip_str}",
+                details={
+                    "url": source,
+                    "hostname": hostname,
+                    "resolved_ip": ip_str,
+                    "reason": "Link-local address (169.254.0.0/16, fe80::/10)",
+                },
+            )
+
+        # Block multicast addresses
+        if ip_addr.is_multicast:
+            raise ValidationError(
+                f"Access to multicast addresses is not allowed: {ip_str}",
+                details={
+                    "url": source,
+                    "hostname": hostname,
+                    "resolved_ip": ip_str,
+                    "reason": "Multicast address",
+                },
+            )
+
+        # Block reserved addresses
+        if ip_addr.is_reserved:
+            raise ValidationError(
+                f"Access to reserved IP addresses is not allowed: {ip_str}",
+                details={
+                    "url": source,
+                    "hostname": hostname,
+                    "resolved_ip": ip_str,
+                    "reason": "Reserved IP address",
+                },
+            )
+
+        # Block private IP addresses (RFC 1918)
+        # Check this LAST because is_private also returns True for loopback and link-local
+        if ip_addr.is_private:
+            raise ValidationError(
+                f"Access to private IP addresses is not allowed: {ip_str}",
+                details={
+                    "url": source,
+                    "hostname": hostname,
+                    "resolved_ip": ip_str,
+                    "reason": "Private IP address (RFC 1918: 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16)",
+                },
+            )
 
 
 class DoclangValidator(InputValidator):

--- a/docling_graph/core/utils/string_formatter.py
+++ b/docling_graph/core/utils/string_formatter.py
@@ -2,8 +2,12 @@
 
 import json
 import re
-from datetime import date, datetime
+from datetime import date, datetime, time
+from decimal import Decimal
+from enum import Enum
+from pathlib import PurePath
 from typing import Any
+from uuid import UUID
 
 
 def format_property_value(value: Any, max_length: int = 80) -> str:
@@ -75,11 +79,28 @@ def truncate_string(text: str, max_length: int, suffix: str = "...") -> str:
 def json_serializable(obj: Any) -> Any:
     """
     Custom JSON serializer for objects not serializable by default.
-    Converts date and datetime to ISO format strings.
-    Raises TypeError for other unknown types.
+
+    Handles the value types a Pydantic extraction template can legitimately put
+    on a graph node — ``date``/``datetime``/``time`` (ISO strings),
+    ``Decimal`` (float), ``UUID``/``Path`` (str), ``set``/``frozenset`` (sorted
+    list), ``bytes`` (utf-8 text), ``Enum`` (its value), and any object exposing
+    ``model_dump`` (Pydantic models). Raises ``TypeError`` for anything else.
     """
-    if isinstance(obj, date | datetime):
+    if isinstance(obj, date | datetime | time):
         return obj.isoformat()
+    if isinstance(obj, Decimal):
+        return float(obj)
+    if isinstance(obj, UUID | PurePath):
+        return str(obj)
+    if isinstance(obj, set | frozenset):
+        return sorted(obj, key=str)
+    if isinstance(obj, bytes):
+        return obj.decode("utf-8", "replace")
+    if isinstance(obj, Enum):
+        return obj.value
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        return model_dump(mode="json")
     raise TypeError(f"Type {type(obj)} not serializable")
 
 

--- a/docling_graph/llm_clients/__init__.py
+++ b/docling_graph/llm_clients/__init__.py
@@ -13,16 +13,15 @@ def get_client(provider: str) -> Type[LiteLLMClient]:
     """
     Get LLM client class for the specified provider.
 
-    Uses lazy imports, so client packages are only loaded when actually used.
+    Every provider is served by the single LiteLLM-backed client; the provider
+    string is resolved later by ``resolve_effective_model_config`` (unknown
+    providers fall back to generic defaults with a warning). This function
+    itself never raises.
 
     Args:
         provider: Provider name (mistral, ollama, vllm, openai, gemini, watsonx)
 
     Returns:
         The client class for the provider
-
-    Raises:
-        ValueError: If provider is not recognized
-        ImportError: If provider package is not installed
     """
     return LiteLLMClient

--- a/docling_graph/pipeline/orchestrator.py
+++ b/docling_graph/pipeline/orchestrator.py
@@ -264,9 +264,18 @@ class PipelineOrchestrator:
             if isinstance(e, PipelineError):
                 raise
 
+            details = {"stage": stage_name, "error": str(e), "error_type": type(e).__name__}
+            # Propagate a stable machine-readable ``reason`` from the wrapped
+            # DoclingGraphError so callers can classify the failure without
+            # parsing the English message (e.g. 'no_models_extracted').
+            cause_details = getattr(e, "details", None)
+            if isinstance(cause_details, dict) and "reason" in cause_details:
+                details["reason"] = cause_details["reason"]
+
             raise PipelineError(
                 f"Pipeline failed at stage '{stage_name}': {type(e).__name__}",
-                details={"stage": stage_name, "error": str(e), "error_type": type(e).__name__},
+                details=details,
+                cause=e,
             ) from e
 
         finally:
@@ -281,18 +290,28 @@ class PipelineOrchestrator:
         """
         logger.info("Cleaning up resources...")
 
+        # A full gc.collect() after every run is a stop-the-world pause that
+        # hurts tail latency for long-lived services running many small jobs.
+        # It stays on by default (CLI / batch); a service can set
+        # PipelineConfig(gc_collect=False) to skip it — the flag is threaded
+        # into the backend/doc-processor cleanups too, which run their own
+        # collects. The CUDA cache purge is kept regardless — it is GPU-memory
+        # hygiene, not a latency cost.
+        collect = bool(getattr(self.config, "gc_collect", True))
+
         if context.extractor:
             if hasattr(context.extractor, "backend"):
                 backend = context.extractor.backend
                 if hasattr(backend, "cleanup"):
-                    backend.cleanup()
+                    _call_cleanup(backend.cleanup, collect)
 
             if hasattr(context.extractor, "doc_processor"):
                 doc_processor = context.extractor.doc_processor
                 if hasattr(doc_processor, "cleanup"):
-                    doc_processor.cleanup()
+                    _call_cleanup(doc_processor.cleanup, collect)
 
-        gc.collect()
+        if collect:
+            gc.collect()
 
         try:
             import torch
@@ -301,6 +320,24 @@ class PipelineOrchestrator:
                 torch.cuda.empty_cache()
         except ImportError:
             pass
+
+
+def _call_cleanup(cleanup_fn: Any, collect: bool) -> None:
+    """Invoke a backend/doc-processor ``cleanup``, forwarding the gc gate.
+
+    In-repo cleanups take ``collect``; a custom backend whose ``cleanup()``
+    predates the flag is still called (it just keeps its own gc behavior).
+    """
+    import inspect
+
+    try:
+        accepts_collect = "collect" in inspect.signature(cleanup_fn).parameters
+    except (TypeError, ValueError):  # builtins/mocks without introspectable signatures
+        accepts_collect = False
+    if accepts_collect:
+        cleanup_fn(collect=collect)
+    else:
+        cleanup_fn()
 
 
 def run_pipeline(

--- a/docling_graph/pipeline/stages.py
+++ b/docling_graph/pipeline/stages.py
@@ -376,7 +376,7 @@ class ExtractionStage(PipelineStage):
         if not context.extracted_models:
             raise ExtractionError(
                 "Extraction produced no models from document",
-                details={"source": context.config.source},
+                details={"source": context.config.source, "reason": "no_models_extracted"},
             )
 
         self.log.info(f"Extracted {len(context.extracted_models)} items")
@@ -675,7 +675,7 @@ class ExtractionStage(PipelineStage):
         if not extracted_models:
             raise ExtractionError(
                 "No models extracted from DoclingDocument",
-                details={"input_type": "docling_document"},
+                details={"input_type": "docling_document", "reason": "no_models_extracted"},
             )
 
         self.log.info(f"Extracted {len(extracted_models)} items from DoclingDocument")

--- a/docling_graph/protocols.py
+++ b/docling_graph/protocols.py
@@ -46,8 +46,14 @@ class ExtractionBackendProtocol(Protocol):
         """
         ...
 
-    def cleanup(self) -> None:
-        """Clean up backend resources (GPU memory, connections, etc.)."""
+    def cleanup(self, collect: bool = True) -> None:
+        """Clean up backend resources (GPU memory, connections, etc.).
+
+        Args:
+            collect: Run a full ``gc.collect()`` as part of cleanup. Long-lived
+                services pass False (``PipelineConfig.gc_collect``) to avoid the
+                per-run stop-the-world pause.
+        """
         ...
 
 
@@ -86,7 +92,7 @@ class TextExtractionBackendProtocol(Protocol):
         """
         ...
 
-    def cleanup(self) -> None:
+    def cleanup(self, collect: bool = True) -> None:
         """Clean up backend resources."""
         ...
 

--- a/docling_graph/templategen/__init__.py
+++ b/docling_graph/templategen/__init__.py
@@ -47,6 +47,7 @@ if TYPE_CHECKING:  # pragma: no cover - static-analysis view of the lazy exports
     from .generate import GenerationResult, generate_template
     from .induce.documents import DocumentContent, induce_spec_from_documents
     from .induce.gapfill import fill_gaps
+    from .llm_call import build_llm_call_fn
     from .ontology import spec_draft_from_ontology
 
 __all__ = [
@@ -63,6 +64,7 @@ __all__ = [
     "TemplateLintError",
     "TemplateSpec",
     "VerificationReport",
+    "build_llm_call_fn",
     "evaluate_template",
     "fill_gaps",
     "generate_template",
@@ -83,6 +85,7 @@ _LAZY_EXPORTS: dict[str, tuple[str, str]] = {
     "DocumentContent": (".induce.documents", "DocumentContent"),
     "EvaluationReport": (".evaluate", "EvaluationReport"),
     "GenerationResult": (".generate", "GenerationResult"),
+    "build_llm_call_fn": (".llm_call", "build_llm_call_fn"),
     "evaluate_template": (".evaluate", "evaluate_template"),
     "fill_gaps": (".induce.gapfill", "fill_gaps"),
     "generate_template": (".generate", "generate_template"),

--- a/docling_graph/templategen/llm_call.py
+++ b/docling_graph/templategen/llm_call.py
@@ -1,0 +1,178 @@
+"""Public constructor for the template-induction ``LlmCallFn``.
+
+``induce_spec_from_documents`` / ``generate_template(kind="docs")`` take an
+injected ``llm_call_fn`` (the ``templategen.induce.documents`` contract). Wiring
+one to a real LiteLLM client is non-trivial — it owns thread-local clients
+(induction fans calls out across ``templategen.workers``), a one-shot
+truncation-escalation retry with a hard 2x ceiling, and provider-safe schema-name
+sanitization. This module exposes that wiring as a public, CLI-free API so
+downstream callers (services, notebooks) do not reimplement it or reach into the
+CLI internals.
+"""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import TYPE_CHECKING, Any
+
+from ..logging_utils import get_component_logger
+
+if TYPE_CHECKING:
+    from ..llm_clients.config import LlmRuntimeOverrides
+    from .induce.documents import LlmCallFn
+
+logger = get_component_logger("TemplateInduction", __name__)
+
+__all__ = ["build_llm_call_fn"]
+
+
+def build_llm_call_fn(
+    provider: str,
+    model: str,
+    *,
+    llm_overrides: LlmRuntimeOverrides | dict[str, Any] | None = None,
+    structured_output: bool = True,
+) -> LlmCallFn:
+    """Bind a thread-safe ``llm_call_fn`` to a LiteLLM client.
+
+    The returned callable follows the ``templategen.induce.documents`` contract
+    (``llm_call_fn(*, prompt, schema_json, context) -> Any``) and owns truncation
+    handling: one retry with escalated ``max_tokens`` (doubled, capped at half the
+    model's context window). The retry fires whether the truncated response was
+    salvaged into JSON or failed to parse outright — the unrecoverable case
+    surfaces as a :class:`~docling_graph.exceptions.ClientError` and needs the
+    escalation the most. The retry's result is returned (or its error raised)
+    either way.
+
+    ``structured_output=False`` (the one-shot induction strategy) requests plain
+    ``json_object`` decoding instead of a schema grammar — small models that
+    degenerate under guided decoding answer normally, and the response handler's
+    fence-stripping/repair absorbs the slack.
+
+    Thread-safe by construction: induction runs calls concurrently
+    (``templategen.workers``), and one shared client would race on
+    ``last_call_diagnostics`` and the escalation's ``max_tokens`` swap — so every
+    thread gets its own client instance (the one built eagerly here doubles as a
+    fail-fast config/dependency check and the building thread's client).
+
+    Args:
+        provider: Provider id (``mistral``, ``openai``, ``ollama``, ``vllm``, ...).
+        model: Model name/path for that provider.
+        llm_overrides: Optional runtime overrides (``LlmRuntimeOverrides`` or the
+            equivalent dict) forwarded to ``resolve_effective_model_config``.
+        structured_output: ``True`` (default, three-pass strategy) uses a schema
+            grammar; ``False`` (one-shot strategy) requests ``json_object``.
+
+    Returns:
+        The bound ``llm_call_fn``.
+
+    Raises:
+        ConfigurationError: The ``litellm`` package is not installed (from eager
+            client construction). Unknown providers do NOT raise — they fall back
+            to generic defaults with a warning — and credentials are not checked
+            here either: a bad key only surfaces as a ``ClientError`` from the
+            returned callable's first real call.
+    """
+    import threading
+
+    from ..exceptions import ClientError
+    from ..llm_clients import get_client
+    from ..llm_clients.config import resolve_effective_model_config
+
+    # resolve_effective_model_config accepts LlmRuntimeOverrides | dict | None.
+    effective = resolve_effective_model_config(provider, model, overrides=llm_overrides)
+    client_factory = get_client(provider)
+
+    thread_clients = threading.local()
+    # Every client gets its own DEEP COPY of the config: the escalation retry
+    # mutates generation.max_tokens, and a config shared across thread clients
+    # lets concurrent escalations compound (4092 -> 8184 -> 16368 -> 65472...)
+    # and race on the restore — the budget must never ratchet across calls.
+    thread_clients.client = client_factory(copy.deepcopy(effective))  # fail fast on config/deps
+    # Escalation baseline is fixed at build time: a retry may double the
+    # CONFIGURED budget once, never the (possibly already escalated) live one.
+    baseline_max_tokens = int(
+        getattr(getattr(effective, "generation", None), "max_tokens", 0)
+        or getattr(effective, "max_output_tokens", 0)
+        or 0
+    )
+
+    def llm_call_fn(*, prompt: dict[str, str], schema_json: str, context: str) -> Any:
+        client = getattr(thread_clients, "client", None)
+        if client is None:
+            client = thread_clients.client = client_factory(copy.deepcopy(effective))
+        # OpenAI-family providers require response_format schema names to match
+        # ^[a-zA-Z0-9_-]+$ (<=64 chars); the context tag carries ':' and the
+        # source filename's '.', so sanitize before it reaches the provider.
+        schema_name = re.sub(r"[^a-zA-Z0-9_-]", "_", context)[:40]
+
+        def call() -> Any:
+            return client.get_json_response(
+                prompt,
+                schema_json,
+                structured_output=structured_output,
+                response_top_level="object",
+                response_schema_name=schema_name,
+            )
+
+        def warn_still_truncated(max_tokens: int) -> None:
+            logger.warning(
+                "Induction call '%s' is still truncated at max_tokens=%d — this pass "
+                "should need far less output, so the model is likely looping "
+                "(degenerate repetition); keeping the salvaged partial result. A "
+                "stronger model is the reliable fix; llm_overrides.max_output_tokens "
+                "raises the budget only if the output is genuinely large",
+                context,
+                max_tokens,
+                extra={"component": "TemplateInduction"},
+            )
+
+        out: Any = None
+        error: ClientError | None = None
+        try:
+            out = call()
+        except ClientError as e:
+            # Truncated output that could not be repaired into JSON raises,
+            # but the client diagnostics still flag the truncation.
+            if not client.last_call_diagnostics.get("truncated"):
+                raise
+            error = e
+        if not client.last_call_diagnostics.get("truncated"):
+            return out
+        generation = getattr(client, "_generation", None)
+        current = int(getattr(client, "max_tokens", 0) or 0)
+        context_limit = int(getattr(client, "context_limit", 0) or 0)
+        # Hard ceiling: one doubling of the configured budget, ever. A model
+        # in a repetition loop truncates at ANY budget; escalating past 2x
+        # only converts junk into minutes of generation time (and timeouts).
+        ceiling = 2 * (baseline_max_tokens or current)
+        if context_limit > 0:
+            ceiling = min(ceiling, context_limit // 2)
+        escalated = min(current * 2, ceiling)
+        if generation is None or current <= 0 or escalated <= current:
+            if error is not None:
+                warn_still_truncated(current)
+                raise error
+            return out
+        logger.warning(
+            "Induction call '%s' was truncated; retrying once with max_tokens=%d",
+            context,
+            escalated,
+            extra={"component": "TemplateInduction"},
+        )
+        original = getattr(generation, "max_tokens", None)
+        try:
+            generation.max_tokens = escalated
+            out = call()
+        except ClientError:
+            if client.last_call_diagnostics.get("truncated"):
+                warn_still_truncated(escalated)
+            raise
+        finally:
+            generation.max_tokens = original
+        if client.last_call_diagnostics.get("truncated"):
+            warn_still_truncated(escalated)
+        return out
+
+    return llm_call_fn

--- a/docling_graph/templategen/renderer.py
+++ b/docling_graph/templategen/renderer.py
@@ -60,8 +60,20 @@ from .snippets import (
     STR_METHOD_TEMPLATE,
     STRING_LIST_VALIDATOR_TEMPLATE,
 )
-from .spec import SCALAR_TYPES, EnumSpec, FieldSpec, ModelSpec, TemplateSpec
+from .spec import SCALAR_TYPES, EnumSpec, FieldSpec, ModelSpec, TemplateSpec, _require_identifier
 from .verify import synthesize_sample_plan
+
+
+def _assert_renderable_identifiers(spec: TemplateSpec) -> None:
+    """Render-time security gate: every interpolated name must be a safe identifier."""
+    _require_identifier(spec.root, "template root")
+    for enum in spec.enums:
+        _require_identifier(enum.name, "enum name")
+    for model in spec.models:
+        _require_identifier(model.name, f"model name (in {model.name!r})")
+        for field in model.fields:
+            _require_identifier(field.name, f"field name (in model {model.name!r})")
+
 
 MAX_LINE = 100
 """Emitted lines aim for the repo's ruff line length (long string literals may
@@ -96,7 +108,19 @@ class _Usage:
 
 
 def render_template(spec: TemplateSpec) -> str:
-    """Render a validated SPEC into a runnable Pydantic template module."""
+    """Render a validated SPEC into a runnable Pydantic template module.
+
+    Raises:
+        ValueError: A model/enum/field name (or the root) is not a safe Python
+            identifier. This is the render-time security gate — the renderer
+            interpolates names raw into source that ``verify_template_source``
+            executes, so a non-identifier name is both a guaranteed
+            ``SyntaxError`` and a code-injection vector. The R20/R21 linter
+            renames keyword/builtin collisions during repair, so specs that
+            went through ``lint_spec``/``repair_draft`` pass this gate; it exists
+            to stop an un-repaired or hand-crafted spec from reaching ``exec``.
+    """
+    _assert_renderable_identifiers(spec)
     enums_by_name = {enum.name: enum for enum in spec.enums}
     models_by_name = {model.name: model for model in spec.models}
     ordered = _ordered_models(spec)

--- a/docling_graph/templategen/spec.py
+++ b/docling_graph/templategen/spec.py
@@ -23,10 +23,45 @@ hand-edit one line and re-render instead of editing generated Python.
 
 from __future__ import annotations
 
+import keyword
 from typing import Any, Literal
 
 import yaml
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+
+def _require_identifier(value: str, kind: str) -> str:
+    """Reject names that cannot safely be emitted as a Python identifier.
+
+    The renderer interpolates model / enum / field names **raw** into generated
+    source, and ``verify_template_source`` executes that source — so an
+    identifier that is not a plain, non-keyword, non-dunder name is both a
+    guaranteed render failure (``SyntaxError``) and, for hostile input, a code-
+    injection vector.
+
+    This is applied by :func:`docling_graph.templategen.render_template` at
+    render time (see its ``_assert_renderable_identifiers``), NOT on ``TemplateSpec``
+    construction — the R20/R21 linter deliberately builds drafts with keyword/
+    builtin names and *renames* them during ``repair_draft``/``lint_spec``, so the
+    IR must remain constructible with such names. The render gate is the final
+    stop for an un-repaired or hand-crafted spec reaching ``exec``.
+
+    Soft keywords (``type``, ``match``, ``case``) are allowed — they are valid
+    identifiers and common document field names.
+    """
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"{kind} must be a non-empty string")
+    if not value.isidentifier():
+        raise ValueError(
+            f"{kind} {value!r} is not a valid Python identifier "
+            "(letters, digits, underscores; not starting with a digit)"
+        )
+    if keyword.iskeyword(value):
+        raise ValueError(f"{kind} {value!r} is a reserved Python keyword")
+    if value.startswith("__") and value.endswith("__"):
+        raise ValueError(f"{kind} {value!r} is a reserved dunder name")
+    return value
+
 
 ScalarType = Literal["str", "int", "float", "bool", "date", "datetime"]
 """Scalar field types the renderer knows how to emit."""

--- a/docling_graph/templategen/verify.py
+++ b/docling_graph/templategen/verify.py
@@ -33,6 +33,7 @@ V7 (``--trial-run``, a real extraction) belongs to the CLI layer, not here.
 from __future__ import annotations
 
 import ast
+import itertools
 import json
 import sys
 import types
@@ -61,7 +62,19 @@ ALLOWED_IMPORT_ROOTS: frozenset[str] = frozenset(
 FORBIDDEN_NAMES: frozenset[str] = frozenset({"exec", "eval", "open", "__import__", "compile"})
 """Builtins whose mere mention fails V1b — templates are declarative modules."""
 
-_EXEC_MODULE_NAME = "docling_graph_generated_template"
+_EXEC_MODULE_PREFIX = "docling_graph_generated_template"
+_exec_module_counter = itertools.count(1)
+
+
+def _next_exec_module_name() -> str:
+    """A unique sys.modules key per verification run.
+
+    A fixed name would make concurrent ``verify_template_source`` calls (e.g. a
+    service compiling templates from parallel requests) overwrite each other's
+    module and pop it mid-exec; ``itertools.count`` is atomic under the GIL.
+    """
+    return f"{_EXEC_MODULE_PREFIX}_{next(_exec_module_counter)}"
+
 
 _GATE_ORDER: tuple[tuple[str, str], ...] = (
     ("V1", "ast parse + file structure"),
@@ -484,13 +497,14 @@ def verify_template_source(
     # through sys.modules[cls.__module__], so a bare dict namespace would
     # defer the model build and fail every schema-touching gate downstream —
     # unlike the imported modules TemplateLoadingStage produces.
-    module = types.ModuleType(_EXEC_MODULE_NAME)
-    module.__file__ = f"<{_EXEC_MODULE_NAME}>"
-    sys.modules[_EXEC_MODULE_NAME] = module
+    exec_module_name = _next_exec_module_name()
+    module = types.ModuleType(exec_module_name)
+    module.__file__ = f"<{exec_module_name}>"
+    sys.modules[exec_module_name] = module
     try:
         namespace: dict[str, Any] = module.__dict__
         try:
-            exec(compile(source, f"<{_EXEC_MODULE_NAME}>", "exec"), namespace)
+            exec(compile(source, f"<{exec_module_name}>", "exec"), namespace)
         except Exception as exc:
             record("V2", False, f"{type(exc).__name__}: {exc}")
             skip_rest("V3", "V2 failed — no live classes")
@@ -506,7 +520,7 @@ def verify_template_source(
         record("V2", True, f"'{root_class}' loads under the TemplateLoadingStage predicate")
         _run_schema_gates(report, record, root_model, namespace, spec)
     finally:
-        sys.modules.pop(_EXEC_MODULE_NAME, None)
+        sys.modules.pop(exec_module_name, None)
 
     return report
 

--- a/docs/fundamentals/graph-management/export-formats.md
+++ b/docs/fundamentals/graph-management/export-formats.md
@@ -418,6 +418,44 @@ print(f"Found {len(invoices)} invoices")
 
 ---
 
+### In-Memory Round Trip (no files)
+
+`JSONExporter` writes to disk and `load_graph_json()` reads from disk. When you already hold the graph or the payload in memory — serving a graph over HTTP, accepting one in a request body — use the file-free pair instead of spooling through a temp file:
+
+```python
+from docling_graph.core.exporters import graph_to_dict
+from docling_graph.core.importers import load_graph_from_dict
+
+payload = graph_to_dict(graph)      # graph -> dict, same shape as graph.json
+graph = load_graph_from_dict(payload)  # dict -> graph
+```
+
+`load_graph_from_dict()` accepts an optional `source=` label used in error messages (a path, URL, or the default `"<dict>"`), and raises `ConfigurationError` when the payload is not a docling-graph export, is empty, or is structurally corrupt (malformed records, dangling edge endpoints):
+
+```python
+from docling_graph.exceptions import ConfigurationError
+
+try:
+    graph = load_graph_from_dict(request_body, source="POST /graphs")
+except ConfigurationError as e:
+    print(f"Rejected: {e.message} ({e.details})")
+```
+
+!!! warning "`graph_to_dict()` output is not directly JSON-encodable"
+
+    The returned dict holds **live** Python values — a `date` stays a `date`, a `Decimal` stays a `Decimal`. Pass `json_serializable` when encoding, exactly as `JSONExporter` does internally:
+
+    ```python
+    import json
+    from docling_graph.core.utils.string_formatter import json_serializable
+
+    encoded = json.dumps(graph_to_dict(graph), default=json_serializable)
+    ```
+
+    This matters for the round trip: handing the dict straight back to `load_graph_from_dict()` preserves the live objects, but going through JSON flattens them (`date` → ISO string, `Decimal` → float). The graph round-trips structurally either way; attribute *types* only survive if you skip the encode step.
+
+---
+
 ## Format Selection
 
 ### Decision Matrix

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -36,6 +36,7 @@ config = PipelineConfig(
     use_chunking: bool = True,
     chunk_max_tokens: int | None = None,
     debug: bool = False,
+    gc_collect: bool = True,
     dump_to_disk: bool | None = None,
     export_format: Literal["csv", "cypher"] = "csv",
     export_docling: bool = True,
@@ -79,6 +80,7 @@ config = PipelineConfig(
 | `chunk_max_tokens` | `int` or `None` | `None` | Max tokens per chunk (default 512 when chunking; raise it when using a DocLang `llm_input_format`) |
 | `debug` | `bool` | `False` | Enable debug artifacts |
 | `parallel_workers` | `int` or `None` | `4` | Parallel workers for extraction (`1` = sequential; `None` uses the default) |
+| `gc_collect` | `bool` | `True` | Run a full `gc.collect()` after each pipeline run. Keep `True` for CLI/batch use; set `False` in a long-lived service to avoid the per-run stop-the-world pause (the CUDA cache purge still runs) |
 
 #### Dense extraction (skeleton-then-flesh)
 

--- a/docs/reference/exporters.md
+++ b/docs/reference/exporters.md
@@ -139,30 +139,44 @@ exporter.export()
 Export graphs to JSON format.
 
 ```python
-class JSONExporter(BaseExporter):
+class JSONExporter:
     """Export graph to JSON format."""
-    
-    def export(self) -> None:
+
+    def __init__(self, config: ExportConfig | None = None) -> None:
         """
-        Export to JSON.
-        
-        Creates:
-            - graph.json: NetworkX node-link format
+        Initialize exporter.
+
+        Args:
+            config: Export configuration. Uses defaults if None.
+        """
+
+    def export(self, graph: nx.DiGraph, output_path: Path) -> None:
+        """
+        Export graph to JSON.
+
+        Args:
+            graph: NetworkX directed graph to export.
+            output_path: File path where to save JSON.
+
+        Raises:
+            ValueError: If graph is empty.
         """
 ```
 
 **Output Format:**
 
+Docling-graph's own shape — *not* NetworkX node-link. Edges live under `edges` (not `links`), and graph-level metadata (the format-v2 identity contract: `id_fields_map`, template name/schema hash) lives under a top-level `graph` key, absent on v1 exports.
+
 ```json
 {
-  "directed": true,
-  "multigraph": true,
   "nodes": [
-    {"id": "node_1", "type": "Person", "name": "John"}
+    {"id": "node_1", "type": "entity", "label": "John"}
   ],
-  "links": [
-    {"source": "node_1", "target": "node_2", "type": "WORKS_AT"}
-  ]
+  "edges": [
+    {"source": "node_1", "target": "node_2", "label": "works_at"}
+  ],
+  "metadata": {"node_count": 2, "edge_count": 1},
+  "graph": {"format": "v2"}
 }
 ```
 
@@ -172,11 +186,101 @@ class JSONExporter(BaseExporter):
 from docling_graph.core.exporters import JSONExporter
 from pathlib import Path
 
-exporter = JSONExporter(graph, Path("outputs"))
-exporter.export()
-
-# File created: outputs/graph.json
+exporter = JSONExporter()
+exporter.export(graph, Path("outputs/graph.json"))
 ```
+
+---
+
+### graph_to_dict
+
+Serialize a graph to the canonical `graph.json` shape without touching the filesystem.
+
+```python
+def graph_to_dict(graph: nx.DiGraph) -> Dict[str, Any]:
+    """
+    Serialize a graph to the canonical docling-graph JSON shape.
+
+    Args:
+        graph: NetworkX directed graph.
+
+    Returns:
+        {"nodes": [...], "edges": [...], "metadata": {...}, "graph": {...}}
+    """
+```
+
+The round-trip inverse is [`load_graph_from_dict()`](#load_graph_from_dict). Use the pair when the graph or payload is already in memory (an HTTP handler, a notebook) and a temp file would be pure overhead.
+
+**Example:**
+
+```python
+from docling_graph.core.exporters import graph_to_dict
+from docling_graph.core.importers import load_graph_from_dict
+
+payload = graph_to_dict(graph)
+restored = load_graph_from_dict(payload)
+```
+
+!!! warning "Output holds live Python values"
+
+    The returned dict is not directly JSON-encodable — a `date` stays a `date`, a `Decimal` stays a `Decimal`. Pass `json_serializable` as `default=`, the way `JSONExporter` does internally:
+
+    ```python
+    import json
+    from docling_graph.core.utils.string_formatter import json_serializable
+
+    encoded = json.dumps(graph_to_dict(graph), default=json_serializable)
+    ```
+
+    Encoding flattens those values (`date` → ISO string, `Decimal` → float); passing the dict straight to `load_graph_from_dict()` keeps them live.
+
+---
+
+## Graph Importer
+
+### load_graph_from_dict
+
+Load an in-memory `graph.json` object back into a graph. The read-side inverse of [`graph_to_dict()`](#graph_to_dict).
+
+**Module:** `docling_graph.core.importers`
+
+```python
+def load_graph_from_dict(data: dict, *, source: str = "<dict>") -> nx.DiGraph:
+    """
+    Load an already-parsed graph.json object into an nx.DiGraph.
+
+    Args:
+        data: A docling-graph graph export object.
+        source: Label used in error messages (a path, URL, or "<dict>").
+
+    Raises:
+        ConfigurationError: When data is not a docling-graph export, is empty,
+            or is structurally corrupt (malformed records, dangling edges).
+    """
+```
+
+Validation is identical to the file-based `load_graph_json()`, which is a thin wrapper over this function. Node `id`s must be JSON scalars; graph-level metadata under `graph` is restored when present and tolerated when absent (v1 exports).
+
+**Example:**
+
+```python
+from docling_graph.core.importers import load_graph_from_dict
+from docling_graph.exceptions import ConfigurationError
+
+try:
+    graph = load_graph_from_dict(request_body, source="POST /graphs")
+except ConfigurationError as e:
+    print(f"Rejected: {e.message} ({e.details})")
+```
+
+**Related file-based loaders** (`docling_graph.core.importers`):
+
+| Function | Description |
+|:---------|:------------|
+| `load_graph_json(path)` | Read and parse one `graph.json` file into a graph |
+| `resolve_graph_path(path)` | Resolve a directory to its `graph.json` (rejects lossy CSV/Cypher) |
+| `load_sibling_ledger(path)` | Load the `provenance.json` written next to `graph.json` |
+| `load_graph_input(path)` | Resolve + load one merge input: `(graph, ledger \| None, path)` |
 
 ---
 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -80,6 +80,7 @@ Graph export formats.
 - `CypherExporter` - Cypher scripts
 - `JSONExporter` - JSON format
 - `DoclingExporter` - Docling documents
+- `graph_to_dict()` / `load_graph_from_dict()` - File-free graph round trip
 
 **[Provenance](provenance.md)**  
 Deterministic node-to-source grounding.
@@ -109,6 +110,7 @@ docling_graph/
 │   ├── converters/          # Graph conversion
 │   ├── extractors/          # Extraction strategies
 │   ├── exporters/           # Export formats
+│   ├── importers/           # Load exported graphs back into NetworkX
 │   ├── provenance/          # Data grounding (deterministic node-to-source)
 │   └── visualizers/         # Visualization
 │
@@ -176,8 +178,12 @@ from docling_graph.core.extractors import OneToOne, ManyToOne
 from docling_graph.core.exporters import (
     CSVExporter,
     CypherExporter,
-    JSONExporter
+    JSONExporter,
+    graph_to_dict
 )
+
+# Importers (file-free round trip)
+from docling_graph.core.importers import load_graph_from_dict
 ```
 
 ---

--- a/docs/usage/api/pipeline-config.md
+++ b/docs/usage/api/pipeline-config.md
@@ -104,6 +104,12 @@ For **dense** extraction, additional options (`dense_skeleton_batch_tokens`, `de
 |-----------|------|---------|-------------|
 | `debug` | `bool` | `False` | Enable debug mode to save all intermediate extraction artifacts |
 
+### Runtime Settings
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `gc_collect` | `bool` | `True` | Run a full `gc.collect()` after each pipeline run. Keep `True` for CLI/batch use; set `False` in a long-lived service to avoid the per-run stop-the-world pause (the CUDA cache purge still runs) |
+
 ### Export Settings
 
 | Parameter | Type | Default | Description |

--- a/docs/usage/cli/template-command.md
+++ b/docs/usage/cli/template-command.md
@@ -162,10 +162,65 @@ result.spec, result.lint_report, result.gaps, result.source_code, result.written
 
 `kind="spec"` re-renders a SPEC YAML; `kind="docs"` (one or many documents) requires an injected `llm_call_fn`.
 
+### Building an `llm_call_fn`
+
+Induction does not create LLM clients itself — it calls an injected `llm_call_fn`, so you stay in control of the provider, model, and credentials. `build_llm_call_fn` binds one to a LiteLLM client for you:
+
+```python
+from docling_graph.templategen import build_llm_call_fn
+
+llm_call_fn = build_llm_call_fn("mistral", "mistral-small-latest")
+```
+
+The returned callable follows the induction contract (`llm_call_fn(*, prompt, schema_json, context)`) and is **thread-safe**: induction fans calls out across `--workers`, so each thread gets its own client.
+
+It also owns truncation handling — if a response comes back truncated, it retries once with `max_tokens` doubled (capped at half the model's context window, and never more than 2x the configured budget). A model stuck in a repetition loop truncates at any budget, so the ceiling stops a runaway from turning junk into minutes of generation time; you get a warning instead.
+
+Optional arguments:
+
+| Argument | Type | Default | Description |
+|----------|------|---------|-------------|
+| `llm_overrides` | `LlmRuntimeOverrides` \| `dict` \| `None` | `None` | Runtime overrides (e.g. `{"max_output_tokens": 8192}`), same shape as the `llm_overrides` block in `config.yaml` |
+| `structured_output` | `bool` | `True` | `True` uses a schema grammar (pair with `strategy="three-pass"`); `False` requests plain `json_object` decoding (pair with `strategy="one-shot"`) |
+
+!!! warning "Pair `structured_output` with your `strategy`"
+
+    The two settings live on different functions — `structured_output` on `build_llm_call_fn`, `strategy` on `induce_spec_from_documents` — and nothing cross-checks them. Mismatching them silently applies grammar-constrained decoding to the `one-shot` strategy, the exact combination `one-shot` exists to avoid for small local models.
+
+    | Strategy | `structured_output` |
+    |:---------|:--------------------|
+    | `three-pass` | `True` |
+    | `one-shot` | `False` |
+
+    The defaults line up (`build_llm_call_fn` → `True`, `induce_spec_from_documents` → `strategy="three-pass"`), so leaving both alone is safe. Note the **CLI** defaults to `one-shot` instead and wires `structured_output` for you; when you switch a programmatic call to `one-shot`, you must flip `structured_output` yourself:
+
+    ```python
+    llm_call_fn = build_llm_call_fn(
+        "ollama",
+        "gemma3:12b",
+        llm_overrides={"max_output_tokens": 8192},
+        structured_output=False,          # ← must match ...
+    )
+
+    spec, report = induce_spec_from_documents(
+        ["invoice1.pdf"],
+        llm_call_fn,
+        strategy="one-shot",              # ← ... this
+    )
+    ```
+
+Construction is offline: it fails fast if `litellm` is missing, but it does **not** validate credentials or reject unknown providers (those fall back to generic defaults with a warning). A bad API key first surfaces as a `ClientError` from the returned callable's first real call.
+
+### Inducing a SPEC
+
 Document sources for `kind="docs"` / `induce_spec_from_documents` can be file paths, `http(s)://` URLs, or — when you already hold the text — `DocumentContent` objects passed directly, no file needed:
 
 ```python
-from docling_graph.templategen import DocumentContent, induce_spec_from_documents
+from docling_graph.templategen import (
+    DocumentContent, build_llm_call_fn, induce_spec_from_documents,
+)
+
+llm_call_fn = build_llm_call_fn("mistral", "mistral-small-latest")
 
 spec, report = induce_spec_from_documents(
     [

--- a/tests/unit/core/importers/test_graph_json.py
+++ b/tests/unit/core/importers/test_graph_json.py
@@ -188,3 +188,47 @@ def test_corrupt_sibling_ledger_degrades_to_none(tmp_path):
     graph_path = _export(graph, tmp_path / "graph.json")
     (graph_path.parent / "provenance.json").write_text("{not json", encoding="utf-8")
     assert load_sibling_ledger(graph_path) is None
+
+
+class TestInMemoryRoundTrip:
+    """load_graph_from_dict / graph_to_dict — the file-free public round trip."""
+
+    def test_round_trip_dict(self):
+        import networkx as nx
+
+        from docling_graph.core.exporters import graph_to_dict
+        from docling_graph.core.importers import load_graph_from_dict
+
+        g = nx.DiGraph()
+        g.add_node("n1", id="n1", label="Doc", type="entity", __class__="Doc", title="A")
+        g.add_node("n2", id="n2", label="Doc", type="entity", __class__="Doc", title="B")
+        g.add_edge("n1", "n2", label="REL")
+        g.graph.update({"format": "docling-graph/v2"})
+
+        data = graph_to_dict(g)
+        g2 = load_graph_from_dict(data)
+        assert g2.number_of_nodes() == 2
+        assert g2.number_of_edges() == 1
+        assert g2.graph.get("format") == "docling-graph/v2"
+
+    def test_rejects_non_export_dict(self):
+        import pytest
+
+        from docling_graph.core.importers import load_graph_from_dict
+        from docling_graph.exceptions import ConfigurationError
+
+        with pytest.raises(ConfigurationError):
+            load_graph_from_dict({"not": "a graph"})
+
+    @pytest.mark.parametrize("bad_id", [None, {"a": 1}, [1, 2]])
+    def test_rejects_non_scalar_node_id(self, bad_id):
+        """A null/object/array id must surface as ConfigurationError, not a raw
+        networkx ValueError/TypeError (the documented contract for HTTP bodies)."""
+        import pytest
+
+        from docling_graph.core.importers import load_graph_from_dict
+        from docling_graph.exceptions import ConfigurationError
+
+        data = {"nodes": [{"id": bad_id, "label": "Doc"}], "edges": []}
+        with pytest.raises(ConfigurationError, match="JSON scalar"):
+            load_graph_from_dict(data)

--- a/tests/unit/core/input/test_handlers.py
+++ b/tests/unit/core/input/test_handlers.py
@@ -1,6 +1,7 @@
 """Unit tests for input handlers."""
 
 import json
+import socket
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch
@@ -14,6 +15,14 @@ from docling_graph.core.input.handlers import (
     URLInputHandler,
 )
 from docling_graph.exceptions import ValidationError
+
+
+def _addrinfo(*ips: str) -> list:
+    """Build a socket.getaddrinfo-style result list for the given IP addresses."""
+    return [
+        (socket.AF_INET6 if ":" in ip else socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))
+        for ip in ips
+    ]
 
 
 class TestTextInputHandler:
@@ -438,13 +447,13 @@ class TestURLInputHandler:
 
     # ==================== SSRF Protection Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_validates_initial_url_safety(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_validates_initial_url_safety(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that initial URL is validated for SSRF before download."""
         # URL resolves to localhost
-        mock_gethostbyname.return_value = "127.0.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("127.0.0.1")
 
         with pytest.raises(ValidationError, match="loopback"):
             handler.load("http://localhost/file.pdf")
@@ -453,22 +462,22 @@ class TestURLInputHandler:
         mock_head.assert_not_called()
         mock_get.assert_not_called()
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_blocks_private_ip_addresses(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_blocks_private_ip_addresses(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that private IP addresses are blocked."""
-        mock_gethostbyname.return_value = "192.168.1.1"
+        mock_getaddrinfo.return_value = _addrinfo("192.168.1.1")
 
         with pytest.raises(ValidationError, match="private"):
             handler.load("http://internal.company.local/file.pdf")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_blocks_cloud_metadata_endpoint(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_blocks_cloud_metadata_endpoint(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that cloud metadata endpoint (169.254.169.254) is explicitly blocked."""
-        mock_gethostbyname.return_value = "169.254.169.254"
+        mock_getaddrinfo.return_value = _addrinfo("169.254.169.254")
 
         with pytest.raises(ValidationError, match="metadata"):
             handler.load("http://metadata.example.com/")
@@ -480,48 +489,48 @@ class TestURLInputHandler:
             assert "169.254.169.254" in str(e)
             assert "Cloud metadata endpoint" in e.details["reason"]
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_blocks_link_local_addresses(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_blocks_link_local_addresses(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that link-local addresses are blocked."""
-        mock_gethostbyname.return_value = "169.254.1.1"
+        mock_getaddrinfo.return_value = _addrinfo("169.254.1.1")
 
         with pytest.raises(ValidationError, match="link-local"):
             handler.load("http://link-local.test/")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_blocks_multicast_addresses(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_blocks_multicast_addresses(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that multicast addresses are blocked."""
-        mock_gethostbyname.return_value = "224.0.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("224.0.0.1")
 
         with pytest.raises(ValidationError, match="multicast"):
             handler.load("http://multicast.test/")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_blocks_reserved_addresses(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_blocks_reserved_addresses(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that reserved IP addresses are blocked."""
-        mock_gethostbyname.return_value = "240.0.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("240.0.0.1")
 
         with pytest.raises(ValidationError, match="reserved"):
             handler.load("http://reserved.test/")
 
-    @patch("socket.gethostbyname")
-    def test_handles_dns_resolution_failure_in_validation(self, mock_gethostbyname, handler):
+    @patch("socket.getaddrinfo")
+    def test_handles_dns_resolution_failure_in_validation(self, mock_getaddrinfo, handler):
         """Test handling of DNS resolution failures during URL validation."""
         import socket as sock
 
-        mock_gethostbyname.side_effect = sock.gaierror("Name or service not known")
+        mock_getaddrinfo.side_effect = sock.gaierror("Name or service not known")
 
         with pytest.raises(ValidationError, match="Failed to resolve hostname"):
             handler.load("http://nonexistent-domain-12345.com/")
 
-    @patch("socket.gethostbyname")
-    def test_handles_invalid_url_without_hostname(self, mock_gethostbyname, handler):
+    @patch("socket.getaddrinfo")
+    def test_handles_invalid_url_without_hostname(self, mock_getaddrinfo, handler):
         """Test handling of invalid URLs without hostname."""
         # This should fail during URL parsing before DNS lookup
         with pytest.raises(ValidationError, match="Invalid URL"):
@@ -529,15 +538,15 @@ class TestURLInputHandler:
 
     # ==================== Manual Redirect Validation Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_validates_redirect_destination_safety(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test that redirect destinations are validated for SSRF."""
         # Initial URL is safe, redirect goes to private IP
-        mock_gethostbyname.side_effect = ["8.8.8.8", "192.168.1.1"]
+        mock_getaddrinfo.side_effect = [_addrinfo("8.8.8.8"), _addrinfo("192.168.1.1")]
 
         # HEAD returns redirect
         mock_head_response = Mock()
@@ -548,14 +557,12 @@ class TestURLInputHandler:
         with pytest.raises(ValidationError, match="private"):
             handler.load("http://public.com/redirect")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_handles_relative_redirect_safely(
-        self, mock_get, mock_head, mock_gethostbyname, handler
-    ):
+    def test_handles_relative_redirect_safely(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that relative redirects are handled and validated."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # HEAD returns relative redirect
         mock_head_response1 = Mock()
@@ -578,11 +585,11 @@ class TestURLInputHandler:
         result = handler.load("http://example.com/old-location")
         assert result.exists()
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
-    def test_enforces_max_redirects_in_head_request(self, mock_head, mock_gethostbyname, handler):
+    def test_enforces_max_redirects_in_head_request(self, mock_head, mock_getaddrinfo, handler):
         """Test that maximum redirect limit is enforced in HEAD requests."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # Create 6 redirects (exceeds limit of 5)
         redirect_responses = []
@@ -597,13 +604,13 @@ class TestURLInputHandler:
         with pytest.raises(ValidationError, match="Too many redirects"):
             handler.load("http://redirect0.com/")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     def test_handles_redirect_without_location_header_in_head(
-        self, mock_head, mock_gethostbyname, handler
+        self, mock_head, mock_getaddrinfo, handler
     ):
         """Test handling of redirect without Location header in HEAD request."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         mock_head_response = Mock()
         mock_head_response.status_code = 302
@@ -613,15 +620,19 @@ class TestURLInputHandler:
         with pytest.raises(ValidationError, match="Location header"):
             handler.load("http://broken-redirect.com/")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_validates_redirects_in_get_request(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test that GET request redirects are also validated."""
         # HEAD fails, so GET is used
-        mock_gethostbyname.side_effect = ["8.8.8.8", "8.8.8.8", "192.168.1.1"]
+        mock_getaddrinfo.side_effect = [
+            _addrinfo("8.8.8.8"),
+            _addrinfo("8.8.8.8"),
+            _addrinfo("192.168.1.1"),
+        ]
 
         # HEAD fails
         import requests
@@ -637,14 +648,14 @@ class TestURLInputHandler:
         with pytest.raises(ValidationError, match="private"):
             handler.load("http://public.com/")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_enforces_max_redirects_in_get_request(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test that maximum redirect limit is enforced in GET requests."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # HEAD fails
         import requests
@@ -664,14 +675,14 @@ class TestURLInputHandler:
         with pytest.raises(ValidationError, match="Too many redirects"):
             handler.load("http://redirect0.com/")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_handles_redirect_without_location_header_in_get(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test handling of redirect without Location header in GET request."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # HEAD fails
         import requests
@@ -687,14 +698,14 @@ class TestURLInputHandler:
         with pytest.raises(ValidationError, match="Location header"):
             handler.load("http://broken-redirect.com/")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_handles_multiple_redirect_status_codes(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test handling of various redirect status codes (301, 302, 303, 307, 308)."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # Test each redirect status code
         for status_code in [301, 302, 303, 307, 308]:

--- a/tests/unit/core/input/test_ssrf_security.py
+++ b/tests/unit/core/input/test_ssrf_security.py
@@ -21,6 +21,14 @@ from docling_graph.core.input.validators import URLValidator
 from docling_graph.exceptions import ValidationError
 
 
+def _addrinfo(*ips: str) -> list:
+    """Build a socket.getaddrinfo-style result list for the given IP addresses."""
+    return [
+        (socket.AF_INET6 if ":" in ip else socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))
+        for ip in ips
+    ]
+
+
 class TestURLValidatorIPBlocking:
     """Tests for URLValidator IP address validation and blocking."""
 
@@ -31,20 +39,20 @@ class TestURLValidatorIPBlocking:
 
     # ==================== Localhost Tests ====================
 
-    @patch("socket.gethostbyname")
-    def test_blocks_localhost_127_0_0_1(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_localhost_127_0_0_1(self, mock_getaddrinfo, validator):
         """Test that localhost (127.0.0.1) is blocked."""
-        mock_gethostbyname.return_value = "127.0.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("127.0.0.1")
 
         with pytest.raises(ValidationError, match="loopback"):
             validator.validate("http://localhost/")
 
-        mock_gethostbyname.assert_called_once_with("localhost")
+        mock_getaddrinfo.assert_called_once_with("localhost", None, proto=socket.IPPROTO_TCP)
 
-    @patch("socket.gethostbyname")
-    def test_blocks_localhost_domain(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_localhost_domain(self, mock_getaddrinfo, validator):
         """Test that 'localhost' domain is blocked."""
-        mock_gethostbyname.return_value = "127.0.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("127.0.0.1")
 
         with pytest.raises(ValidationError) as exc_info:
             validator.validate("https://localhost:8080/api")
@@ -63,10 +71,10 @@ class TestURLValidatorIPBlocking:
             "127.255.255.255",
         ],
     )
-    @patch("socket.gethostbyname")
-    def test_blocks_loopback_range(self, mock_gethostbyname, validator, ip_address):
+    @patch("socket.getaddrinfo")
+    def test_blocks_loopback_range(self, mock_getaddrinfo, validator, ip_address):
         """Test that all loopback addresses (127.0.0.0/8) are blocked."""
-        mock_gethostbyname.return_value = ip_address
+        mock_getaddrinfo.return_value = _addrinfo(ip_address)
 
         with pytest.raises(ValidationError, match="loopback"):
             validator.validate("http://test.example.com/")
@@ -94,10 +102,10 @@ class TestURLValidatorIPBlocking:
             ("192.168.1.100", "192.168.0.0/16"),
         ],
     )
-    @patch("socket.gethostbyname")
-    def test_blocks_private_networks(self, mock_gethostbyname, validator, ip_address, network):
+    @patch("socket.getaddrinfo")
+    def test_blocks_private_networks(self, mock_getaddrinfo, validator, ip_address, network):
         """Test that private IP addresses (RFC 1918) are blocked."""
-        mock_gethostbyname.return_value = ip_address
+        mock_getaddrinfo.return_value = _addrinfo(ip_address)
 
         with pytest.raises(ValidationError, match="private"):
             validator.validate("http://internal.company.com/")
@@ -120,10 +128,10 @@ class TestURLValidatorIPBlocking:
             "169.254.100.50",
         ],
     )
-    @patch("socket.gethostbyname")
-    def test_blocks_link_local_addresses(self, mock_gethostbyname, validator, ip_address):
+    @patch("socket.getaddrinfo")
+    def test_blocks_link_local_addresses(self, mock_getaddrinfo, validator, ip_address):
         """Test that link-local addresses (169.254.0.0/16) are blocked."""
-        mock_gethostbyname.return_value = ip_address
+        mock_getaddrinfo.return_value = _addrinfo(ip_address)
 
         with pytest.raises(ValidationError, match="link-local"):
             validator.validate("http://link-local.test/")
@@ -137,10 +145,10 @@ class TestURLValidatorIPBlocking:
 
     # ==================== Cloud Metadata Endpoint Tests ====================
 
-    @patch("socket.gethostbyname")
-    def test_blocks_cloud_metadata_endpoint_explicit(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_cloud_metadata_endpoint_explicit(self, mock_getaddrinfo, validator):
         """Test explicit blocking of cloud metadata endpoint (169.254.169.254)."""
-        mock_gethostbyname.return_value = "169.254.169.254"
+        mock_getaddrinfo.return_value = _addrinfo("169.254.169.254")
 
         with pytest.raises(ValidationError, match="metadata"):
             validator.validate("http://metadata.example.com/")
@@ -153,21 +161,21 @@ class TestURLValidatorIPBlocking:
             assert "metadata" in str(e).lower()
             assert "AWS" in e.details["reason"] or "cloud" in e.details["reason"].lower()
 
-    @patch("socket.gethostbyname")
-    def test_blocks_metadata_endpoint_with_path(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_metadata_endpoint_with_path(self, mock_getaddrinfo, validator):
         """Test that metadata endpoint is blocked even with specific paths."""
-        mock_gethostbyname.return_value = "169.254.169.254"
+        mock_getaddrinfo.return_value = _addrinfo("169.254.169.254")
 
         with pytest.raises(ValidationError, match="metadata"):
             validator.validate("http://evil.com/latest/meta-data/iam/security-credentials/")
 
     # ==================== IPv6 Tests ====================
 
-    @patch("socket.gethostbyname")
-    def test_blocks_ipv6_loopback(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_ipv6_loopback(self, mock_getaddrinfo, validator):
         """Test that IPv6 loopback (::1) is blocked."""
-        # Note: socket.gethostbyname returns IPv4, but ipaddress handles IPv6
-        mock_gethostbyname.return_value = "::1"
+        # socket.getaddrinfo returns AAAA records natively for IPv6 hosts
+        mock_getaddrinfo.return_value = _addrinfo("::1")
 
         with pytest.raises(ValidationError, match="loopback"):
             validator.validate("http://[::1]/")
@@ -180,13 +188,36 @@ class TestURLValidatorIPBlocking:
             "fe80::1234:5678:90ab:cdef",
         ],
     )
-    @patch("socket.gethostbyname")
-    def test_blocks_ipv6_link_local(self, mock_gethostbyname, validator, ipv6_address):
+    @patch("socket.getaddrinfo")
+    def test_blocks_ipv6_link_local(self, mock_getaddrinfo, validator, ipv6_address):
         """Test that IPv6 link-local addresses (fe80::/10) are blocked."""
-        mock_gethostbyname.return_value = ipv6_address
+        mock_getaddrinfo.return_value = _addrinfo(ipv6_address)
 
         with pytest.raises(ValidationError, match="link-local"):
             validator.validate(f"http://[{ipv6_address}]/")
+
+    # ==================== Multi-Record Resolution Tests ====================
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_multi_record_private_sibling(self, mock_getaddrinfo, validator):
+        """Test that a private record cannot hide behind a public sibling record.
+
+        A hostname may resolve to several A/AAAA records; the downloader can
+        connect to any of them, so every resolved address must be validated,
+        not just the first one (multi-record SSRF bypass).
+        """
+        mock_getaddrinfo.return_value = _addrinfo("93.184.216.34", "10.0.0.5")
+
+        with pytest.raises(ValidationError, match="private"):
+            validator.validate("http://multi-record.example.com/")
+
+    @patch("socket.getaddrinfo")
+    def test_blocks_hostname_resolving_to_ipv6_loopback(self, mock_getaddrinfo, validator):
+        """Test that a hostname whose AAAA record is the IPv6 loopback (::1) is blocked."""
+        mock_getaddrinfo.return_value = _addrinfo("::1")
+
+        with pytest.raises(ValidationError, match="loopback"):
+            validator.validate("http://sneaky-host.example.com/")
 
     # ==================== Multicast Address Tests ====================
 
@@ -198,10 +229,10 @@ class TestURLValidatorIPBlocking:
             "230.1.2.3",
         ],
     )
-    @patch("socket.gethostbyname")
-    def test_blocks_multicast_addresses(self, mock_gethostbyname, validator, ip_address):
+    @patch("socket.getaddrinfo")
+    def test_blocks_multicast_addresses(self, mock_getaddrinfo, validator, ip_address):
         """Test that multicast addresses are blocked."""
-        mock_gethostbyname.return_value = ip_address
+        mock_getaddrinfo.return_value = _addrinfo(ip_address)
 
         with pytest.raises(ValidationError, match="multicast"):
             validator.validate("http://multicast.test/")
@@ -216,10 +247,10 @@ class TestURLValidatorIPBlocking:
             "255.255.255.255",
         ],
     )
-    @patch("socket.gethostbyname")
-    def test_blocks_reserved_addresses(self, mock_gethostbyname, validator, ip_address):
+    @patch("socket.getaddrinfo")
+    def test_blocks_reserved_addresses(self, mock_getaddrinfo, validator, ip_address):
         """Test that reserved IP addresses are blocked."""
-        mock_gethostbyname.return_value = ip_address
+        mock_getaddrinfo.return_value = _addrinfo(ip_address)
 
         with pytest.raises(ValidationError, match="reserved"):
             validator.validate("http://reserved.test/")
@@ -236,22 +267,22 @@ class TestURLValidatorIPBlocking:
             ("13.107.42.14", "Microsoft"),
         ],
     )
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     def test_allows_legitimate_public_ips(
-        self, mock_gethostbyname, validator, ip_address, description
+        self, mock_getaddrinfo, validator, ip_address, description
     ):
         """Test that legitimate public IP addresses are allowed."""
-        mock_gethostbyname.return_value = ip_address
+        mock_getaddrinfo.return_value = _addrinfo(ip_address)
 
         # Should not raise any exception
         validator.validate("https://legitimate-site.com/")
 
     # ==================== DNS Resolution Failure Tests ====================
 
-    @patch("socket.gethostbyname")
-    def test_handles_dns_resolution_failure(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_handles_dns_resolution_failure(self, mock_getaddrinfo, validator):
         """Test handling of DNS resolution failures."""
-        mock_gethostbyname.side_effect = socket.gaierror("Name or service not known")
+        mock_getaddrinfo.side_effect = socket.gaierror("Name or service not known")
 
         with pytest.raises(ValidationError, match="Failed to resolve hostname"):
             validator.validate("http://nonexistent-domain-12345.com/")
@@ -263,10 +294,13 @@ class TestURLValidatorIPBlocking:
             assert "nonexistent-domain-12345.com" in e.details["hostname"]
             assert "hint" in e.details
 
-    @patch("socket.gethostbyname")
-    def test_handles_dns_timeout(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_handles_dns_timeout(self, mock_getaddrinfo, validator):
         """Test handling of DNS timeout errors."""
-        mock_gethostbyname.side_effect = TimeoutError("DNS lookup timed out")
+        # getaddrinfo surfaces DNS timeouts as gaierror(EAI_AGAIN)
+        mock_getaddrinfo.side_effect = socket.gaierror(
+            socket.EAI_AGAIN, "Temporary failure in name resolution"
+        )
 
         with pytest.raises(ValidationError):
             validator.validate("http://slow-dns.example.com/")
@@ -282,13 +316,13 @@ class TestURLInputHandlerRedirectSecurity:
 
     # ==================== Redirect to Internal IP Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_blocks_redirect_to_localhost(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_blocks_redirect_to_localhost(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that redirects to localhost are blocked."""
         # Initial URL resolves to public IP
-        mock_gethostbyname.side_effect = ["93.184.216.34", "127.0.0.1"]
+        mock_getaddrinfo.side_effect = [_addrinfo("93.184.216.34"), _addrinfo("127.0.0.1")]
 
         # HEAD request returns redirect to localhost
         mock_head_response = Mock()
@@ -299,15 +333,15 @@ class TestURLInputHandlerRedirectSecurity:
         with pytest.raises(ValidationError, match="loopback"):
             handler.load("http://attacker.com/redirect")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_blocks_redirect_to_private_network(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test that redirects to private networks are blocked."""
         # Initial URL resolves to public IP, redirect resolves to private IP
-        mock_gethostbyname.side_effect = ["8.8.8.8", "192.168.1.1"]
+        mock_getaddrinfo.side_effect = [_addrinfo("8.8.8.8"), _addrinfo("192.168.1.1")]
 
         # HEAD request returns redirect to private network
         mock_head_response = Mock()
@@ -318,20 +352,46 @@ class TestURLInputHandlerRedirectSecurity:
         with pytest.raises(ValidationError, match="private"):
             handler.load("http://evil.com/redirect-to-internal")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
+    @patch("requests.head")
+    @patch("requests.get")
+    def test_blocks_redirect_to_multi_record_private_sibling(
+        self, mock_get, mock_head, mock_getaddrinfo, handler
+    ):
+        """Test that a redirect target with a private sibling record is blocked.
+
+        The redirect destination hostname resolves to both a public and a private
+        address. The handler validates every resolved record, so the private
+        sibling must be rejected even though a public record is present.
+        """
+        # Initial URL is public; the redirect destination resolves to [public, private].
+        mock_getaddrinfo.side_effect = [
+            _addrinfo("8.8.8.8"),
+            _addrinfo("93.184.216.34", "10.0.0.5"),
+        ]
+
+        mock_head_response = Mock()
+        mock_head_response.status_code = 302
+        mock_head_response.headers = {"Location": "http://multi-record.attacker.com/secrets"}
+        mock_head.return_value = mock_head_response
+
+        with pytest.raises(ValidationError, match="private"):
+            handler.load("http://evil.com/redirect-to-multi-record")
+
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_blocks_redirect_to_metadata_endpoint(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test that redirects to cloud metadata endpoints are blocked (PoC from security report)."""
         # Initial URL resolves to public IP, redirect resolves to metadata endpoint
         # Need to provide enough values for all DNS lookups (initial + redirect validation)
-        mock_gethostbyname.side_effect = [
-            "1.2.3.4",
-            "169.254.169.254",
-            "1.2.3.4",
-            "169.254.169.254",
+        mock_getaddrinfo.side_effect = [
+            _addrinfo("1.2.3.4"),
+            _addrinfo("169.254.169.254"),
+            _addrinfo("1.2.3.4"),
+            _addrinfo("169.254.169.254"),
         ]
 
         # HEAD request returns redirect to metadata endpoint
@@ -349,12 +409,12 @@ class TestURLInputHandlerRedirectSecurity:
         except ValidationError as e:
             assert "169.254.169.254" in str(e)
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_blocks_redirect_to_link_local(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_blocks_redirect_to_link_local(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that redirects to link-local addresses are blocked."""
-        mock_gethostbyname.side_effect = ["8.8.8.8", "169.254.1.1"]
+        mock_getaddrinfo.side_effect = [_addrinfo("8.8.8.8"), _addrinfo("169.254.1.1")]
 
         mock_head_response = Mock()
         mock_head_response.status_code = 302
@@ -366,15 +426,15 @@ class TestURLInputHandlerRedirectSecurity:
 
     # ==================== Legitimate Redirect Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_allows_legitimate_redirect_to_public_url(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test that legitimate redirects to public URLs work correctly."""
         # Both URLs resolve to public IPs
-        mock_gethostbyname.side_effect = ["93.184.216.34", "151.101.1.140"]
+        mock_getaddrinfo.side_effect = [_addrinfo("93.184.216.34"), _addrinfo("151.101.1.140")]
 
         # HEAD request returns redirect to another public URL
         mock_head_response1 = Mock()
@@ -401,12 +461,12 @@ class TestURLInputHandlerRedirectSecurity:
 
     # ==================== Maximum Redirect Limit Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
-    def test_enforces_maximum_redirect_limit(self, mock_head, mock_gethostbyname, handler):
+    def test_enforces_maximum_redirect_limit(self, mock_head, mock_getaddrinfo, handler):
         """Test that maximum redirect limit (5) is enforced."""
         # All URLs resolve to public IPs
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # Create a chain of 6 redirects (exceeds limit of 5)
         redirect_responses = []
@@ -421,12 +481,12 @@ class TestURLInputHandlerRedirectSecurity:
         with pytest.raises(ValidationError, match="Too many redirects"):
             handler.load("http://redirect0.com/")
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_allows_exactly_five_redirects(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_allows_exactly_five_redirects(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test that exactly 5 redirects are allowed."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # Create exactly 5 redirects, then success
         redirect_responses = []
@@ -456,11 +516,11 @@ class TestURLInputHandlerRedirectSecurity:
 
     # ==================== Redirect Loop Detection Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
-    def test_detects_redirect_loop(self, mock_head, mock_gethostbyname, handler):
+    def test_detects_redirect_loop(self, mock_head, mock_getaddrinfo, handler):
         """Test detection of redirect loops."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # Create a redirect loop: A -> B -> A
         response_a = Mock()
@@ -485,12 +545,12 @@ class TestURLInputHandlerRedirectSecurity:
 
     # ==================== Relative Redirect Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
-    def test_handles_relative_redirect_url(self, mock_get, mock_head, mock_gethostbyname, handler):
+    def test_handles_relative_redirect_url(self, mock_get, mock_head, mock_getaddrinfo, handler):
         """Test handling of relative redirect URLs."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # HEAD request returns relative redirect
         mock_head_response1 = Mock()
@@ -513,12 +573,12 @@ class TestURLInputHandlerRedirectSecurity:
         result = handler.load("https://example.com/old-path/")
         assert result.exists()
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
-    def test_blocks_relative_redirect_to_localhost(self, mock_head, mock_gethostbyname, handler):
+    def test_blocks_relative_redirect_to_localhost(self, mock_head, mock_getaddrinfo, handler):
         """Test that relative redirects cannot bypass security by redirecting to localhost."""
         # Initial URL is public, but relative redirect tries to go to localhost
-        mock_gethostbyname.side_effect = ["8.8.8.8", "127.0.0.1"]
+        mock_getaddrinfo.side_effect = [_addrinfo("8.8.8.8"), _addrinfo("127.0.0.1")]
 
         # This is a tricky case: relative redirect that somehow resolves to localhost
         # In practice, this would require DNS rebinding or similar attack
@@ -532,11 +592,11 @@ class TestURLInputHandlerRedirectSecurity:
 
     # ==================== Missing Location Header Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
-    def test_handles_redirect_without_location_header(self, mock_head, mock_gethostbyname, handler):
+    def test_handles_redirect_without_location_header(self, mock_head, mock_getaddrinfo, handler):
         """Test handling of redirect response without Location header."""
-        mock_gethostbyname.return_value = "8.8.8.8"
+        mock_getaddrinfo.return_value = _addrinfo("8.8.8.8")
 
         # Redirect without Location header
         mock_head_response = Mock()
@@ -549,15 +609,19 @@ class TestURLInputHandlerRedirectSecurity:
 
     # ==================== Both HEAD and GET Validation Tests ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
     @patch("requests.get")
     def test_validates_redirects_in_both_head_and_get(
-        self, mock_get, mock_head, mock_gethostbyname, handler
+        self, mock_get, mock_head, mock_getaddrinfo, handler
     ):
         """Test that both HEAD and GET requests validate redirects."""
         # HEAD succeeds, but GET has a redirect to internal IP
-        mock_gethostbyname.side_effect = ["8.8.8.8", "8.8.8.8", "192.168.1.1"]
+        mock_getaddrinfo.side_effect = [
+            _addrinfo("8.8.8.8"),
+            _addrinfo("8.8.8.8"),
+            _addrinfo("192.168.1.1"),
+        ]
 
         # HEAD request succeeds
         mock_head_response = Mock()
@@ -591,9 +655,9 @@ class TestSSRFIntegrationScenarios:
 
     # ==================== PoC from Security Report ====================
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
-    def test_poc_redirect_to_metadata_endpoint(self, mock_head, mock_gethostbyname, handler):
+    def test_poc_redirect_to_metadata_endpoint(self, mock_head, mock_getaddrinfo, handler):
         """
         Test the exact PoC from the security report.
 
@@ -605,11 +669,11 @@ class TestSSRFIntegrationScenarios:
         # Attacker's server resolves to public IP (use a truly public IP)
         # Redirect target resolves to metadata endpoint
         # Need to provide enough values for all DNS lookups
-        mock_gethostbyname.side_effect = [
-            "8.8.8.8",
-            "169.254.169.254",
-            "8.8.8.8",
-            "169.254.169.254",
+        mock_getaddrinfo.side_effect = [
+            _addrinfo("8.8.8.8"),
+            _addrinfo("169.254.169.254"),
+            _addrinfo("8.8.8.8"),
+            _addrinfo("169.254.169.254"),
         ]
 
         # Attacker's server returns redirect
@@ -629,34 +693,34 @@ class TestSSRFIntegrationScenarios:
 
     # ==================== Direct Access Attempts ====================
 
-    @patch("socket.gethostbyname")
-    def test_blocks_direct_access_to_internal_service(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_direct_access_to_internal_service(self, mock_getaddrinfo, validator):
         """Test blocking direct access attempts to internal services."""
-        mock_gethostbyname.return_value = "10.0.0.5"
+        mock_getaddrinfo.return_value = _addrinfo("10.0.0.5")
 
         with pytest.raises(ValidationError, match="private"):
             validator.validate("http://internal-api.company.local/api/secrets")
 
-    @patch("socket.gethostbyname")
-    def test_blocks_direct_access_to_localhost_service(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_direct_access_to_localhost_service(self, mock_getaddrinfo, validator):
         """Test blocking direct access to localhost services."""
-        mock_gethostbyname.return_value = "127.0.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("127.0.0.1")
 
         with pytest.raises(ValidationError, match="loopback"):
             validator.validate("http://localhost:6379/")  # Redis default port
 
-    @patch("socket.gethostbyname")
-    def test_blocks_direct_metadata_endpoint_access(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_direct_metadata_endpoint_access(self, mock_getaddrinfo, validator):
         """Test blocking direct access to metadata endpoint."""
-        mock_gethostbyname.return_value = "169.254.169.254"
+        mock_getaddrinfo.return_value = _addrinfo("169.254.169.254")
 
         with pytest.raises(ValidationError, match="metadata"):
             validator.validate("http://169.254.169.254/latest/meta-data/")
 
     # ==================== DNS Rebinding Scenarios ====================
 
-    @patch("socket.gethostbyname")
-    def test_dns_rebinding_attempt_initial_public_then_private(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_dns_rebinding_attempt_initial_public_then_private(self, mock_getaddrinfo, validator):
         """
         Test DNS rebinding attack scenario.
 
@@ -668,7 +732,7 @@ class TestSSRFIntegrationScenarios:
         Our defense: We validate on every request/redirect.
         """
         # Simulate DNS rebinding: first call returns public, second returns private
-        mock_gethostbyname.side_effect = ["8.8.8.8", "192.168.1.1"]
+        mock_getaddrinfo.side_effect = [_addrinfo("8.8.8.8"), _addrinfo("192.168.1.1")]
 
         # First validation passes
         validator.validate("http://rebinding-attack.com/")
@@ -689,31 +753,31 @@ class TestSSRFIntegrationScenarios:
             ("http://169.254.169.254/", "metadata"),
         ],
     )
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     def test_various_direct_attack_vectors(
-        self, mock_gethostbyname, validator, attack_url, expected_error
+        self, mock_getaddrinfo, validator, attack_url, expected_error
     ):
         """Test various direct attack vectors are blocked."""
         # Extract IP from URL for mocking
         if "127.0.0.1" in attack_url:
-            mock_gethostbyname.return_value = "127.0.0.1"
+            mock_getaddrinfo.return_value = _addrinfo("127.0.0.1")
         elif "localhost" in attack_url:
-            mock_gethostbyname.return_value = "127.0.0.1"
+            mock_getaddrinfo.return_value = _addrinfo("127.0.0.1")
         elif "::1" in attack_url:
-            mock_gethostbyname.return_value = "::1"
+            mock_getaddrinfo.return_value = _addrinfo("::1")
         elif "0.0.0.0" in attack_url:
-            mock_gethostbyname.return_value = "0.0.0.0"
+            mock_getaddrinfo.return_value = _addrinfo("0.0.0.0")
             # 0.0.0.0 is caught by is_private before is_reserved, so adjust expectation
             expected_error = "private"
         elif "169.254.169.254" in attack_url:
-            mock_gethostbyname.return_value = "169.254.169.254"
+            mock_getaddrinfo.return_value = _addrinfo("169.254.169.254")
 
         with pytest.raises(ValidationError, match=expected_error):
             validator.validate(attack_url)
 
-    @patch("socket.gethostbyname")
+    @patch("socket.getaddrinfo")
     @patch("requests.head")
-    def test_multi_hop_redirect_attack(self, mock_head, mock_gethostbyname, handler):
+    def test_multi_hop_redirect_attack(self, mock_head, mock_getaddrinfo, handler):
         """
         Test multi-hop redirect attack.
 
@@ -724,7 +788,11 @@ class TestSSRFIntegrationScenarios:
         All redirects should be validated.
         """
         # DNS resolutions: attacker.com, cdn.attacker.com, internal.local
-        mock_gethostbyname.side_effect = ["203.0.113.1", "203.0.113.2", "192.168.1.1"]
+        mock_getaddrinfo.side_effect = [
+            _addrinfo("203.0.113.1"),
+            _addrinfo("203.0.113.2"),
+            _addrinfo("192.168.1.1"),
+        ]
 
         # First redirect: attacker.com -> cdn.attacker.com
         response1 = Mock()
@@ -742,18 +810,18 @@ class TestSSRFIntegrationScenarios:
         with pytest.raises(ValidationError, match="private"):
             handler.load("http://attacker.com/start")
 
-    @patch("socket.gethostbyname")
-    def test_blocks_access_to_docker_internal(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_access_to_docker_internal(self, mock_getaddrinfo, validator):
         """Test blocking access to Docker internal network."""
-        mock_gethostbyname.return_value = "172.17.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("172.17.0.1")
 
         with pytest.raises(ValidationError, match="private"):
             validator.validate("http://docker-internal.local/")
 
-    @patch("socket.gethostbyname")
-    def test_blocks_access_to_kubernetes_service(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_blocks_access_to_kubernetes_service(self, mock_getaddrinfo, validator):
         """Test blocking access to Kubernetes internal services."""
-        mock_gethostbyname.return_value = "10.96.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("10.96.0.1")
 
         with pytest.raises(ValidationError, match="private"):
             validator.validate("http://kubernetes.default.svc.cluster.local/")
@@ -767,10 +835,10 @@ class TestSSRFErrorMessages:
         """Create URLValidator instance."""
         return URLValidator()
 
-    @patch("socket.gethostbyname")
-    def test_error_message_includes_resolved_ip(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_error_message_includes_resolved_ip(self, mock_getaddrinfo, validator):
         """Test that error messages include the resolved IP address."""
-        mock_gethostbyname.return_value = "192.168.1.1"
+        mock_getaddrinfo.return_value = _addrinfo("192.168.1.1")
 
         try:
             validator.validate("http://internal.local/")
@@ -778,20 +846,20 @@ class TestSSRFErrorMessages:
             assert "192.168.1.1" in str(e)
             assert e.details["resolved_ip"] == "192.168.1.1"
 
-    @patch("socket.gethostbyname")
-    def test_error_message_includes_hostname(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_error_message_includes_hostname(self, mock_getaddrinfo, validator):
         """Test that error messages include the original hostname."""
-        mock_gethostbyname.return_value = "127.0.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("127.0.0.1")
 
         try:
             validator.validate("http://localhost:8080/admin")
         except ValidationError as e:
             assert "localhost" in e.details["hostname"]
 
-    @patch("socket.gethostbyname")
-    def test_error_message_includes_reason(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_error_message_includes_reason(self, mock_getaddrinfo, validator):
         """Test that error messages include the reason for blocking."""
-        mock_gethostbyname.return_value = "169.254.169.254"
+        mock_getaddrinfo.return_value = _addrinfo("169.254.169.254")
 
         try:
             validator.validate("http://metadata.local/")
@@ -801,20 +869,20 @@ class TestSSRFErrorMessages:
                 "metadata" in e.details["reason"].lower() or "cloud" in e.details["reason"].lower()
             )
 
-    @patch("socket.gethostbyname")
-    def test_error_message_includes_rfc_reference(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_error_message_includes_rfc_reference(self, mock_getaddrinfo, validator):
         """Test that error messages include RFC references for private networks."""
-        mock_gethostbyname.return_value = "10.0.0.1"
+        mock_getaddrinfo.return_value = _addrinfo("10.0.0.1")
 
         try:
             validator.validate("http://internal.local/")
         except ValidationError as e:
             assert "RFC 1918" in e.details["reason"]
 
-    @patch("socket.gethostbyname")
-    def test_dns_error_message_is_clear(self, mock_gethostbyname, validator):
+    @patch("socket.getaddrinfo")
+    def test_dns_error_message_is_clear(self, mock_getaddrinfo, validator):
         """Test that DNS resolution errors have clear messages."""
-        mock_gethostbyname.side_effect = socket.gaierror("Name or service not known")
+        mock_getaddrinfo.side_effect = socket.gaierror("Name or service not known")
 
         try:
             validator.validate("http://nonexistent-domain-xyz.com/")

--- a/tests/unit/core/input/test_validators.py
+++ b/tests/unit/core/input/test_validators.py
@@ -1,6 +1,7 @@
 """Unit tests for input validators."""
 
 import json
+import socket
 import tempfile
 from pathlib import Path
 
@@ -12,6 +13,14 @@ from docling_graph.core.input.validators import (
     URLValidator,
 )
 from docling_graph.exceptions import ValidationError
+
+
+def _addrinfo(*ips: str) -> list:
+    """Build a socket.getaddrinfo-style result list for the given IP addresses."""
+    return [
+        (socket.AF_INET6 if ":" in ip else socket.AF_INET, socket.SOCK_STREAM, 6, "", (ip, 0))
+        for ip in ips
+    ]
 
 
 class TestTextValidator:
@@ -90,7 +99,9 @@ class TestURLValidator:
         ]
 
         # Mock DNS resolution to return a public IP address
-        with patch("socket.gethostbyname", return_value="93.184.216.34"):  # example.com's actual IP
+        with patch(
+            "socket.getaddrinfo", return_value=_addrinfo("93.184.216.34")
+        ):  # example.com's actual IP
             for url in valid_urls:
                 validator.validate(url)  # Should not raise
 
@@ -106,7 +117,9 @@ class TestURLValidator:
         ]
 
         # Mock DNS resolution to return a public IP address
-        with patch("socket.gethostbyname", return_value="93.184.216.34"):  # example.com's actual IP
+        with patch(
+            "socket.getaddrinfo", return_value=_addrinfo("93.184.216.34")
+        ):  # example.com's actual IP
             for url in valid_urls:
                 validator.validate(url)  # Should not raise
 

--- a/tests/unit/core/utils/test_string_formatter.py
+++ b/tests/unit/core/utils/test_string_formatter.py
@@ -175,3 +175,76 @@ class TestTruncateString:
 
         assert len(result) == 5
         assert result.endswith("~")
+
+
+class TestJsonSerializableWidened:
+    """The widened json_serializable default used by JSONExporter."""
+
+    def test_date_and_datetime(self):
+        import datetime
+
+        from docling_graph.core.utils.string_formatter import json_serializable
+
+        assert json_serializable(datetime.date(2025, 1, 2)) == "2025-01-02"
+        assert json_serializable(datetime.datetime(2025, 1, 2, 3, 4, 5)).startswith(
+            "2025-01-02T03:04:05"
+        )
+        assert json_serializable(datetime.time(3, 4, 5)) == "03:04:05"
+
+    def test_decimal_uuid_path(self):
+        import decimal
+        import uuid
+        from pathlib import PurePosixPath
+
+        from docling_graph.core.utils.string_formatter import json_serializable
+
+        assert json_serializable(decimal.Decimal("1.5")) == 1.5
+        assert json_serializable(uuid.UUID(int=0)) == "00000000-0000-0000-0000-000000000000"
+        assert json_serializable(PurePosixPath("/a/b")) == "/a/b"
+
+    def test_set_is_sorted_list(self):
+        from docling_graph.core.utils.string_formatter import json_serializable
+
+        assert json_serializable({3, 1, 2}) == [1, 2, 3]
+        assert json_serializable(frozenset({"b", "a"})) == ["a", "b"]
+
+    def test_bytes_and_enum(self):
+        import enum
+
+        from docling_graph.core.utils.string_formatter import json_serializable
+
+        assert json_serializable(b"hi") == "hi"
+
+        class Color(enum.Enum):
+            RED = "red"
+
+        assert json_serializable(Color.RED) == "red"
+
+    def test_pydantic_model_dump(self):
+        from pydantic import BaseModel
+
+        from docling_graph.core.utils.string_formatter import json_serializable
+
+        class M(BaseModel):
+            a: int = 1
+
+        assert json_serializable(M()) == {"a": 1}
+
+    def test_unknown_type_raises(self):
+        import pytest
+
+        from docling_graph.core.utils.string_formatter import json_serializable
+
+        with pytest.raises(TypeError):
+            json_serializable(object())
+
+    def test_end_to_end_json_dumps(self):
+        import datetime
+        import json
+        import uuid
+
+        from docling_graph.core.utils.string_formatter import json_serializable
+
+        payload = {"when": datetime.date(2025, 1, 1), "id": uuid.UUID(int=1), "tags": {"b", "a"}}
+        blob = json.dumps(payload, default=json_serializable)
+        assert "2025-01-01" in blob and "00000000-0000-0000-0000-000000000001" in blob

--- a/tests/unit/pipeline/test_gc_collect.py
+++ b/tests/unit/pipeline/test_gc_collect.py
@@ -1,0 +1,63 @@
+"""PipelineConfig.gc_collect gates the per-run gc.collect() in _cleanup."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, create_autospec, patch
+
+from docling_graph.config import PipelineConfig
+from docling_graph.pipeline.context import PipelineContext
+from docling_graph.pipeline.orchestrator import PipelineOrchestrator
+
+
+def _cleanup_with(gc_collect: bool) -> bool:
+    """Run _cleanup with a bare context; return whether gc.collect was called."""
+    orch = PipelineOrchestrator(PipelineConfig(gc_collect=gc_collect), mode="api")
+    ctx = PipelineContext(config=orch.config)
+    ctx.extractor = None  # nothing to clean up beyond gc
+    with patch("docling_graph.pipeline.orchestrator.gc.collect") as gc_collect_mock:
+        orch._cleanup(ctx)
+        return gc_collect_mock.called
+
+
+def test_gc_collect_true_calls_gc():
+    assert _cleanup_with(gc_collect=True) is True
+
+
+def test_gc_collect_false_skips_gc():
+    assert _cleanup_with(gc_collect=False) is False
+
+
+def test_gc_collect_defaults_true():
+    assert PipelineConfig().gc_collect is True
+
+
+def _extractor_cleanup_collect_args(gc_collect: bool) -> tuple[bool, bool]:
+    """Run _cleanup with a mock extractor; return the collect= each cleanup got."""
+    orch = PipelineOrchestrator(PipelineConfig(gc_collect=gc_collect), mode="api")
+    ctx = PipelineContext(config=orch.config)
+
+    def _cleanup_sig(collect: bool = True) -> None: ...
+
+    # create_autospec preserves the signature, so the orchestrator's
+    # inspect-based forwarding sees the collect parameter.
+    backend = MagicMock()
+    backend.cleanup = create_autospec(_cleanup_sig)
+    doc_processor = MagicMock()
+    doc_processor.cleanup = create_autospec(_cleanup_sig)
+    ctx.extractor = MagicMock()
+    ctx.extractor.backend = backend
+    ctx.extractor.doc_processor = doc_processor
+
+    with patch("docling_graph.pipeline.orchestrator.gc.collect"):
+        orch._cleanup(ctx)
+    return (
+        backend.cleanup.call_args.kwargs.get("collect"),
+        doc_processor.cleanup.call_args.kwargs.get("collect"),
+    )
+
+
+def test_gc_collect_flag_reaches_backend_and_doc_processor_cleanups():
+    """gc_collect=False must gate the backends' internal gc.collect() calls too,
+    or a long-lived service still pays the stop-the-world pause every run."""
+    assert _extractor_cleanup_collect_args(gc_collect=False) == (False, False)
+    assert _extractor_cleanup_collect_args(gc_collect=True) == (True, True)

--- a/tests/unit/templategen/test_llm_call.py
+++ b/tests/unit/templategen/test_llm_call.py
@@ -1,0 +1,181 @@
+"""Unit tests for the public ``build_llm_call_fn`` templategen API.
+
+Exercises the ``LlmCallFn`` contract (keyword-only ``prompt``/``schema_json``/
+``context`` -> Any), provider-safe schema-name sanitization, the eager
+fail-fast client construction, and the one-shot truncation-escalation retry —
+all against a fake client so no network or real provider is required.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+
+import pytest
+
+
+class _FakeGeneration:
+    def __init__(self, max_tokens: int) -> None:
+        self.max_tokens = max_tokens
+
+
+class _FakeClient:
+    """Minimal stand-in for a LiteLLMClient satisfying the builder's duck-typing."""
+
+    def __init__(self, effective: Any, *, truncate_first_call: bool = False) -> None:
+        self.effective = effective
+        self._generation = _FakeGeneration(100)
+        self.max_tokens = 100
+        self.context_limit = 4096
+        self.model = "fake-model"
+        self.last_call_diagnostics: dict[str, Any] = {}
+        self.calls: list[dict[str, Any]] = []
+        self._truncate_first_call = truncate_first_call
+
+    def get_json_response(
+        self,
+        prompt: dict | str,
+        schema_json: str,
+        structured_output: bool = True,
+        response_top_level: str = "object",
+        response_schema_name: str = "extraction_result",
+    ) -> dict:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "schema_json": schema_json,
+                "structured_output": structured_output,
+                "response_top_level": response_top_level,
+                "response_schema_name": response_schema_name,
+                "max_tokens": self._generation.max_tokens,
+            }
+        )
+        if self._truncate_first_call and len(self.calls) == 1:
+            self.last_call_diagnostics = {"truncated": True}
+            return {"partial": True}
+        self.last_call_diagnostics = {"truncated": False}
+        return {"ok": True, "call": len(self.calls)}
+
+
+class _FakeEffective:
+    def __init__(self) -> None:
+        self.generation = _FakeGeneration(200)
+        self.max_output_tokens = 200
+
+
+@pytest.fixture
+def patched_builder(monkeypatch):
+    """Patch the builder's provider resolution to use fake clients.
+
+    Returns a list that collects every constructed fake client so tests can
+    assert on eager construction and per-call behavior.
+    """
+    import docling_graph.llm_clients as llm_clients
+    import docling_graph.llm_clients.config as llm_config
+
+    created: list[_FakeClient] = []
+    state = {"truncate_first_call": False}
+
+    def fake_get_client(provider: str) -> Any:
+        def factory(effective: Any) -> _FakeClient:
+            client = _FakeClient(effective, truncate_first_call=state["truncate_first_call"])
+            created.append(client)
+            return client
+
+        return factory
+
+    monkeypatch.setattr(llm_clients, "get_client", fake_get_client)
+    monkeypatch.setattr(
+        llm_config,
+        "resolve_effective_model_config",
+        lambda provider, model, overrides=None: _FakeEffective(),
+    )
+    return created, state
+
+
+def test_returns_callable_satisfying_the_contract(patched_builder):
+    from docling_graph.templategen import build_llm_call_fn
+
+    created, _ = patched_builder
+    fn = build_llm_call_fn("mistral", "mistral-small-latest")
+
+    assert callable(fn)
+    # Eager fail-fast: one client built at construction time, before any call.
+    assert len(created) == 1
+    assert created[0].calls == []
+
+    out = fn(prompt={"system": "s", "user": "u"}, schema_json="{}", context="Root")
+    assert out == {"ok": True, "call": 1}
+    # Same-thread call reuses the eagerly built client (no new client).
+    assert len(created) == 1
+    assert len(created[0].calls) == 1
+
+
+def test_call_is_keyword_only(patched_builder):
+    from docling_graph.templategen import build_llm_call_fn
+
+    fn = build_llm_call_fn("mistral", "mistral-small-latest")
+    with pytest.raises(TypeError):
+        fn({"user": "u"}, "{}", "Root")  # type: ignore[call-arg]
+
+
+def test_schema_name_is_sanitized_for_providers(patched_builder):
+    from docling_graph.templategen import build_llm_call_fn
+
+    created, _ = patched_builder
+    fn = build_llm_call_fn("openai", "gpt-4o-mini")
+    # ':' (context tag) and '.' (filename) are illegal in response_format names.
+    fn(prompt={"user": "u"}, schema_json="{}", context="Invoice:line_item.total")
+
+    schema_name = created[0].calls[0]["response_schema_name"]
+    assert schema_name == "Invoice_line_item_total"
+    assert len(schema_name) <= 40
+
+
+def test_structured_output_flag_is_forwarded(patched_builder):
+    from docling_graph.templategen import build_llm_call_fn
+
+    created, _ = patched_builder
+    fn = build_llm_call_fn("mistral", "m", structured_output=False)
+    fn(prompt={"user": "u"}, schema_json="{}", context="Root")
+    assert created[0].calls[0]["structured_output"] is False
+
+
+def test_truncation_triggers_one_escalated_retry(patched_builder):
+    from docling_graph.templategen import build_llm_call_fn
+
+    created, state = patched_builder
+    state["truncate_first_call"] = True
+    fn = build_llm_call_fn("mistral", "mistral-small-latest")
+
+    out = fn(prompt={"user": "u"}, schema_json="{}", context="Root")
+
+    client = created[0]
+    # Exactly two calls: the truncated one and one escalated retry.
+    assert len(client.calls) == 2
+    # First call at the configured budget (100); retry doubled to 200
+    # (min(current*2=200, ceiling=min(2*baseline=400, context//2=2048))).
+    assert client.calls[0]["max_tokens"] == 100
+    assert client.calls[1]["max_tokens"] == 200
+    # The retry's result is returned.
+    assert out == {"ok": True, "call": 2}
+    # The live generation budget is restored after the retry.
+    assert client._generation.max_tokens == 100
+
+
+def test_each_thread_gets_its_own_client(patched_builder):
+    from docling_graph.templategen import build_llm_call_fn
+
+    created, _ = patched_builder
+    fn = build_llm_call_fn("mistral", "mistral-small-latest")
+    assert len(created) == 1  # eager client on the building thread
+
+    def worker() -> None:
+        fn(prompt={"user": "u"}, schema_json="{}", context="Root")
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join()
+
+    # The worker thread lazily constructed its own client (no shared state).
+    assert len(created) == 2

--- a/tests/unit/templategen/test_renderer.py
+++ b/tests/unit/templategen/test_renderer.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import pytest
 
 from docling_graph.templategen.renderer import render_template
-from docling_graph.templategen.spec import ModelSpec, TemplateSpec
+from docling_graph.templategen.spec import FieldSpec, ModelSpec, TemplateSpec
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 FIXTURES = REPO_ROOT / "tests" / "fixtures" / "templategen"
@@ -392,3 +392,49 @@ def test_backslashes_in_docstrings_render_parseable_source():
     )
     class_doc = ast.get_docstring(person)
     assert class_doc is not None and "\\Users\\xavier\\exports" in class_doc
+
+
+class TestRenderSecurityGate:
+    """render_template must reject non-identifier names before emitting source.
+
+    The renderer interpolates names raw into source that verify_template_source
+    executes, so a non-identifier name is a code-injection vector. The R20/R21
+    linter renames keyword collisions during repair; this gate is the final
+    stop for an un-repaired or hand-crafted spec reaching exec.
+    """
+
+    @staticmethod
+    def _root_spec(field: FieldSpec) -> TemplateSpec:
+        model = ModelSpec(
+            name="Root",
+            kind="root",
+            docstring="A root document.",
+            identity_fields=["name"],
+            fields=[FieldSpec(name="name", type="str", role="identity"), field],
+        )
+        return TemplateSpec(root="Root", models=[model])
+
+    def test_injection_field_name_rejected_before_exec(self, tmp_path):
+        marker = tmp_path / "pwned.txt"
+        evil = f'x = __import__("pathlib").Path({str(marker)!r}).write_text("P")  #'
+        spec = self._root_spec(FieldSpec(name=evil, type="str", role="property"))
+        with pytest.raises(ValueError, match="not a valid Python identifier"):
+            render_template(spec)
+        assert not marker.exists()  # no code ran
+
+    def test_keyword_field_name_rejected(self):
+        spec = self._root_spec(FieldSpec(name="class", type="str", role="property"))
+        with pytest.raises(ValueError, match="reserved Python keyword"):
+            render_template(spec)
+
+    def test_dunder_field_name_rejected(self):
+        spec = self._root_spec(FieldSpec(name="__class__", type="str", role="property"))
+        with pytest.raises(ValueError, match="reserved dunder"):
+            render_template(spec)
+
+    def test_soft_keyword_field_name_allowed(self):
+        # 'type'/'match'/'case' are valid identifiers and common document fields.
+        for soft in ("type", "match", "case"):
+            spec = self._root_spec(FieldSpec(name=soft, type="str", role="property"))
+            src = render_template(spec)
+            assert f"    {soft}:" in src

--- a/tests/unit/templategen/test_reverse.py
+++ b/tests/unit/templategen/test_reverse.py
@@ -611,6 +611,7 @@ class TestPublicApi:
         "EvaluationReport",
         "generate_template",
         "GenerationResult",
+        "build_llm_call_fn",
         "TemplateGenSettings",
         "load_templategen_settings",
     ]

--- a/uv.lock
+++ b/uv.lock
@@ -1300,7 +1300,7 @@ chunking-openai = [
 
 [[package]]
 name = "docling-graph"
-version = "1.7.1"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Description

Hardens two security surfaces and adds several APIs needed to run docling-graph as an embedded/long-lived service rather than only a CLI batch job:

- **SSRF guard**: `URLValidator`/`URLInputHandler` used to resolve a hostname with `socket.gethostbyname` (first A record only) and validate just that one IP. A multi-homed attacker-controlled hostname could return a safe IP first and a private/loopback/metadata IP later in the A/AAAA list, which the downloader could still connect to. Now every resolved address (via `getaddrinfo`) is validated, and both entry points share one `URLValidator._validate_ip` gate so they can't drift apart again.
- **Template-gen injection gate**: `render_template` interpolates model/enum/field names raw into generated Python that `verify_template_source` then `exec`s. A non-identifier name (or an un-repaired/hand-crafted spec) was a code-injection vector, not just a `SyntaxError` risk. Added `_require_identifier` and a render-time `_assert_renderable_identifiers` gate. Also gave `verify_template_source` a unique `sys.modules` key per call so concurrent verification runs can no longer clobber each other's exec'd module.
- **Service-friendly pipeline controls**: new `PipelineConfig.gc_collect` (default `True`) lets a long-lived service skip the per-run stop-the-world `gc.collect()` (the CUDA cache purge still always runs); threaded through `PipelineOrchestrator`, `LlmBackend`, `VlmBackend`, and `DocumentProcessor` cleanup methods. `PipelineOrchestrator` also now propagates a stable machine-readable `reason` (e.g. `no_models_extracted`) from wrapped `DoclingGraphError`s and attaches the original exception via `cause=e`, so API callers can classify failures without parsing English messages.
- **New public, file-free APIs**:
  - `docling_graph.templategen.build_llm_call_fn` — extracts the CLI's LiteLLM-wiring/truncation-escalation logic (previously buried in `cli/commands/template.py`) into a public, thread-safe constructor so services/notebooks can drive `induce_spec_from_documents` without reimplementing it.
  - `docling_graph.core.exporters.graph_to_dict` / `docling_graph.core.importers.load_graph_from_dict` — round-trip a graph to/from an in-memory dict without spooling through a temp file (the read side also now rejects non-scalar node `id`s with a `ConfigurationError` instead of leaking a raw networkx error).
- **Widened `json_serializable`**: now handles `time`, `Decimal`, `UUID`, `Path`, `set`/`frozenset`, `bytes`, `Enum`, and any Pydantic model (`model_dump`) — value types a real extraction template can legitimately put on a graph node, previously only `date`/`datetime` were handled.

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Code refactoring
- [ ] Performance improvement
- [x] Test addition or update

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run `uv run pre-commit run --all-files` and all checks pass
- [x] I have signed off my commits with `git commit -s` (DCO)

## Testing

- `uv run pytest tests/unit/templategen/test_llm_call.py tests/unit/templategen/test_renderer.py tests/unit/core/importers/test_graph_json.py tests/unit/core/utils/test_string_formatter.py tests/unit/pipeline/test_gc_collect.py tests/unit/core/input/test_ssrf_security.py tests/unit/core/input/test_handlers.py tests/unit/core/input/test_validators.py -q` → 270 passed
- Full unit suite: `uv run pytest --ignore=tests/integration -q` → 2631 passed
- `uv run pre-commit run --all-files` → Ruff formatter, Ruff linter, MyPy, Pytest, uv-lock all passed